### PR TITLE
fix(auth): prevent redirect loop – no cookie clear on refresh failure…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,8 @@ GITHUB_API_KEY="your_github_api_key_here"             # Optional: For GitHub imp
 # Supabase Configuration (Required for database operations)
 NEXT_PUBLIC_SUPABASE_URL="https://your-project.supabase.co"
 NEXT_PUBLIC_SUPABASE_ANON_KEY="your-anon-key-here"
+# Must be the service_role JWT from Supabase (Project Settings → API), NOT the anon key.
+# Using the anon key causes "row-level security policy" errors when saving user_sessions.
 SUPABASE_SERVICE_ROLE_KEY="your-service-role-key-here"
 
 # Apify Configuration (Required for data scraping)

--- a/__tests__/api/onboarding/route.test.ts
+++ b/__tests__/api/onboarding/route.test.ts
@@ -17,7 +17,7 @@ const mockSingle = jest.fn()
 const mockUpsert = jest.fn()
 
 jest.mock('@/lib/supabase', () => ({
-  getSupabaseAdmin: jest.fn(() => ({
+  createSupabaseServiceRoleClient: jest.fn(() => ({
     from: mockFrom,
   })),
 }))

--- a/__tests__/auth/auth-utils-refresh-db.test.ts
+++ b/__tests__/auth/auth-utils-refresh-db.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Ensures refreshAccessToken updates user_sessions with columns that exist in the schema
+ * (last_activity only — no access_token / refresh_token / updated_at).
+ */
+
+import { NextRequest } from 'next/server'
+
+const mockRefreshSession = jest.fn()
+
+let userSessionsFromCall = 0
+let lastUserSessionsUpdatePayload: Record<string, unknown> | undefined
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn(() =>
+    Promise.resolve({
+      get: jest.fn(),
+      set: jest.fn(),
+      delete: jest.fn(),
+    })
+  ),
+}))
+
+jest.mock('@/lib/supabase', () => ({
+  getSupabaseAdmin: jest.fn(() => ({
+    auth: {
+      refreshSession: (...args: unknown[]) => mockRefreshSession(...args),
+    },
+  })),
+  createSupabaseServiceRoleClient: jest.fn(() => ({
+    from: jest.fn(() => {
+      userSessionsFromCall += 1
+      if (userSessionsFromCall === 1) {
+        return {
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          single: jest.fn().mockResolvedValue({ data: { is_active: true }, error: null }),
+        }
+      }
+      return {
+        update: jest.fn((payload: Record<string, unknown>) => {
+          lastUserSessionsUpdatePayload = payload
+          return {
+            eq: jest.fn().mockResolvedValue({ error: null }),
+          }
+        }),
+      }
+    }),
+  })),
+}))
+
+describe('auth-utils refreshAccessToken user_sessions update', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    userSessionsFromCall = 0
+    lastUserSessionsUpdatePayload = undefined
+    mockRefreshSession.mockResolvedValue({
+      data: {
+        session: {
+          access_token: 'new-access',
+          refresh_token: 'new-refresh',
+          expires_at: Math.floor(Date.now() / 1000) + 3600,
+        },
+      },
+      error: null,
+    })
+  })
+
+  it('updates only last_activity (no token columns)', async () => {
+    const { refreshAccessToken } = await import('@/lib/auth-utils')
+
+    const request = new NextRequest('http://localhost:3000/test', {
+      headers: { cookie: 'sb-refresh-token=fake-refresh; sb-session-id=sess-abc' },
+    })
+
+    const result = await refreshAccessToken(request)
+
+    expect(result.success).toBe(true)
+    expect(result.newToken).toBe('new-access')
+    expect(lastUserSessionsUpdatePayload).toBeDefined()
+    expect(Object.keys(lastUserSessionsUpdatePayload!)).toEqual(['last_activity'])
+    expect(typeof lastUserSessionsUpdatePayload!.last_activity).toBe('string')
+    expect(lastUserSessionsUpdatePayload).not.toHaveProperty('access_token')
+    expect(lastUserSessionsUpdatePayload).not.toHaveProperty('refresh_token')
+    expect(lastUserSessionsUpdatePayload).not.toHaveProperty('updated_at')
+  })
+})

--- a/__tests__/auth/auth-utils-refresh-db.test.ts
+++ b/__tests__/auth/auth-utils-refresh-db.test.ts
@@ -7,8 +7,8 @@ import { NextRequest } from 'next/server'
 
 const mockRefreshSession = jest.fn()
 
-let userSessionsFromCall = 0
 let lastUserSessionsUpdatePayload: Record<string, unknown> | undefined
+const mockFrom = jest.fn()
 
 jest.mock('next/headers', () => ({
   cookies: jest.fn(() =>
@@ -27,31 +27,13 @@ jest.mock('@/lib/supabase', () => ({
     },
   })),
   createSupabaseServiceRoleClient: jest.fn(() => ({
-    from: jest.fn(() => {
-      userSessionsFromCall += 1
-      if (userSessionsFromCall === 1) {
-        return {
-          select: jest.fn().mockReturnThis(),
-          eq: jest.fn().mockReturnThis(),
-          single: jest.fn().mockResolvedValue({ data: { is_active: true }, error: null }),
-        }
-      }
-      return {
-        update: jest.fn((payload: Record<string, unknown>) => {
-          lastUserSessionsUpdatePayload = payload
-          return {
-            eq: jest.fn().mockResolvedValue({ error: null }),
-          }
-        }),
-      }
-    }),
+    from: (...args: unknown[]) => mockFrom(...args),
   })),
 }))
 
 describe('auth-utils refreshAccessToken user_sessions update', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    userSessionsFromCall = 0
     lastUserSessionsUpdatePayload = undefined
     mockRefreshSession.mockResolvedValue({
       data: {
@@ -62,6 +44,25 @@ describe('auth-utils refreshAccessToken user_sessions update', () => {
         },
       },
       error: null,
+    })
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'user_sessions') {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              single: jest.fn().mockResolvedValue({ data: { is_active: true }, error: null }),
+            }),
+          }),
+          update: jest.fn((payload: Record<string, unknown>) => {
+            lastUserSessionsUpdatePayload = payload
+            return {
+              eq: jest.fn().mockResolvedValue({ error: null }),
+            }
+          }),
+        }
+      }
+      return {}
     })
   })
 
@@ -76,6 +77,7 @@ describe('auth-utils refreshAccessToken user_sessions update', () => {
 
     expect(result.success).toBe(true)
     expect(result.newToken).toBe('new-access')
+    expect(mockFrom).toHaveBeenCalledWith('user_sessions')
     expect(lastUserSessionsUpdatePayload).toBeDefined()
     expect(Object.keys(lastUserSessionsUpdatePayload!)).toEqual(['last_activity'])
     expect(typeof lastUserSessionsUpdatePayload!.last_activity).toBe('string')

--- a/__tests__/auth/auth-utils.test.ts
+++ b/__tests__/auth/auth-utils.test.ts
@@ -1,17 +1,130 @@
-// Auth utils tests are skipped as they require server-side environment
-// These functions have complex dependencies (Supabase, Next.js server context)
-// that are difficult to mock in a Jest environment.
-// Consider using E2E tests or integration tests for these functions.
+/**
+ * Integration-style tests for auth flows (refresh + login) with mocked Supabase and JWT helpers.
+ */
 
-describe('Authentication Utilities', () => {
-  it('should have placeholder test', () => {
-    expect(true).toBe(true)
+import { NextRequest, NextResponse } from 'next/server'
+
+const mockValidateAccessToken = jest.fn()
+const mockJwtRefreshAccessToken = jest.fn()
+const mockSignInWithPassword = jest.fn()
+const mockUserSessionsInsert = jest.fn()
+
+jest.mock('@/lib/rate-limiting', () => ({
+  withRateLimit: () => (_req: NextRequest, handler: (r: NextRequest) => Promise<Response>) =>
+    handler(_req),
+  clearRateLimit: jest.fn(),
+}))
+
+jest.mock('@/lib/activity-logging', () => ({
+  logAuthEvent: jest.fn().mockResolvedValue(undefined),
+  ActivityLevel: { INFO: 'info' },
+}))
+
+jest.mock('@/lib/jwt-utils', () => ({
+  validateAccessToken: (...args: unknown[]) => mockValidateAccessToken(...args),
+  refreshAccessToken: (...args: unknown[]) => mockJwtRefreshAccessToken(...args),
+  isTokenNearExpiry: jest.fn().mockReturnValue(false),
+}))
+
+jest.mock('@/lib/session-management', () => {
+  const actual = jest.requireActual('@/lib/session-management') as Record<string, unknown>
+  return {
+    ...actual,
+    createEnhancedSession: jest.fn(() => Promise.reject(new Error('enhanced session failed'))),
+  }
+})
+
+jest.mock('@/lib/supabase', () => ({
+  getSupabaseAdmin: jest.fn(() => ({
+    auth: {
+      signInWithPassword: (...args: unknown[]) => mockSignInWithPassword(...args),
+    },
+    from: (table: string) => {
+      if (table === 'user_sessions') {
+        return {
+          insert: (...args: unknown[]) => mockUserSessionsInsert(...args),
+        }
+      }
+      return {
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        single: jest.fn().mockResolvedValue({ data: { role: 'VIEWER' }, error: null }),
+      }
+    },
+  })),
+}))
+
+function refreshPostRequest() {
+  return new NextRequest('http://localhost:3000/api/auth/refresh', {
+    method: 'POST',
+    headers: {
+      cookie: [
+        'sb-auth-token=fake-access',
+        'sb-refresh-token=fake-refresh',
+        'sb-session-id=sess-test',
+      ].join('; '),
+    },
+  })
+}
+
+describe('Authentication flows (integration-style)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
   })
 
-  // These utilities integrate with Next.js request/response objects and Supabase.
-  // Detailed behavior (session creation, refresh & deactivation) should be covered
-  // by higher-level integration/E2E tests rather than unit tests in this file.
-  it.todo(
-    'documents that auth utils rely on server-side environment and are verified by integration/E2E tests'
-  )
+  describe('POST /api/auth/refresh', () => {
+    it('returns 401 on refresh failure without clearing auth cookies', async () => {
+      mockValidateAccessToken.mockResolvedValue({
+        isValid: true,
+        isExpired: false,
+        needsRefresh: true,
+        userId: 'user-1',
+        expiresAt: Math.floor(Date.now() / 1000) + 60,
+      })
+      mockJwtRefreshAccessToken.mockResolvedValue({ success: false, error: 'Token refresh failed' })
+
+      const { POST } = await import('@/app/api/auth/refresh/route')
+      const response = (await POST(refreshPostRequest())) as NextResponse
+      const body = await response.json()
+
+      expect(response.status).toBe(401)
+      expect(body.error).toBeDefined()
+      expect(mockJwtRefreshAccessToken).toHaveBeenCalledWith('fake-refresh')
+
+      expect(response.headers.get('set-cookie')).toBeFalsy()
+    })
+  })
+
+  describe('POST /api/auth/login', () => {
+    it('returns 500 and does not set session cookies when user_sessions insert fails', async () => {
+      mockSignInWithPassword.mockResolvedValue({
+        data: {
+          user: { id: 'user-login-1', email: 'u@example.com' },
+          session: {
+            access_token: 'new-access',
+            refresh_token: 'new-refresh',
+            expires_at: Math.floor(Date.now() / 1000) + 3600,
+          },
+        },
+        error: null,
+      })
+      mockUserSessionsInsert.mockResolvedValue({ error: { message: 'insert failed' } })
+
+      const { POST } = await import('@/app/api/auth/login/route')
+      const request = new NextRequest('http://localhost:3000/api/auth/login', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ email: 'u@example.com', password: 'secret' }),
+      })
+
+      const response = (await POST(request)) as NextResponse
+      const body = await response.json()
+
+      expect(response.status).toBe(500)
+      expect(body.error).toBeDefined()
+      expect(response.cookies.get('sb-auth-token')?.value).toBeUndefined()
+      expect(response.cookies.get('sb-session-id')?.value).toBeUndefined()
+      expect(mockUserSessionsInsert).toHaveBeenCalled()
+    })
+  })
 })

--- a/__tests__/auth/auth-utils.test.ts
+++ b/__tests__/auth/auth-utils.test.ts
@@ -7,4 +7,11 @@ describe('Authentication Utilities', () => {
   it('should have placeholder test', () => {
     expect(true).toBe(true)
   })
+
+  it('documents that auth utils rely on server-side environment', () => {
+    // These utilities integrate with Next.js request/response objects and Supabase.
+    // Detailed behavior (session creation, refresh & deactivation) is covered by
+    // higher-level integration/E2E tests rather than unit tests in this file.
+    expect(typeof process.env.NODE_ENV).toBe('string')
+  })
 })

--- a/__tests__/auth/auth-utils.test.ts
+++ b/__tests__/auth/auth-utils.test.ts
@@ -34,6 +34,12 @@ jest.mock('@/lib/session-management', () => {
   }
 })
 
+function mockUserSessionsTable() {
+  return {
+    insert: (...args: unknown[]) => mockUserSessionsInsert(...args),
+  }
+}
+
 jest.mock('@/lib/supabase', () => ({
   getSupabaseAdmin: jest.fn(() => ({
     auth: {
@@ -41,9 +47,7 @@ jest.mock('@/lib/supabase', () => ({
     },
     from: (table: string) => {
       if (table === 'user_sessions') {
-        return {
-          insert: (...args: unknown[]) => mockUserSessionsInsert(...args),
-        }
+        return mockUserSessionsTable()
       }
       return {
         select: jest.fn().mockReturnThis(),
@@ -52,6 +56,19 @@ jest.mock('@/lib/supabase', () => ({
       }
     },
   })),
+  createSupabaseServiceRoleClient: jest.fn(() => ({
+    from: (table: string) => {
+      if (table === 'user_sessions') {
+        return mockUserSessionsTable()
+      }
+      return {
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        single: jest.fn().mockResolvedValue({ data: null, error: null }),
+      }
+    },
+  })),
+  getSupabaseServiceKeyMisconfigurationMessage: jest.fn(() => null),
 }))
 
 function refreshPostRequest() {

--- a/__tests__/auth/auth-utils.test.ts
+++ b/__tests__/auth/auth-utils.test.ts
@@ -8,10 +8,10 @@ describe('Authentication Utilities', () => {
     expect(true).toBe(true)
   })
 
-  it('documents that auth utils rely on server-side environment', () => {
-    // These utilities integrate with Next.js request/response objects and Supabase.
-    // Detailed behavior (session creation, refresh & deactivation) is covered by
-    // higher-level integration/E2E tests rather than unit tests in this file.
-    expect(typeof process.env.NODE_ENV).toBe('string')
-  })
+  // These utilities integrate with Next.js request/response objects and Supabase.
+  // Detailed behavior (session creation, refresh & deactivation) should be covered
+  // by higher-level integration/E2E tests rather than unit tests in this file.
+  it.todo(
+    'documents that auth utils rely on server-side environment and are verified by integration/E2E tests'
+  )
 })

--- a/__tests__/auth/use-auth.test.tsx
+++ b/__tests__/auth/use-auth.test.tsx
@@ -183,11 +183,53 @@ describe('useAuth Hook', () => {
         if (url === '/api/auth/register') {
           return Promise.resolve({
             ok: true,
+            status: 200,
             json: jest.fn().mockResolvedValue({
               success: true,
               user: {
                 id: 'new-user-id',
                 email: 'newuser@example.com',
+              },
+              session: { expires_at: 1234567890 },
+            }),
+          })
+        }
+      })
+
+      await act(async () => {
+        const out = await result.current.register({
+          email: 'newuser@example.com',
+          password: 'password123',
+          first_name: 'Test',
+          last_name: 'User',
+        })
+        expect(out.requiresManualLogin).toBeUndefined()
+      })
+
+      expect(result.current.user).toBeDefined()
+      expect(result.current.user?.email).toBe('newuser@example.com')
+    })
+
+    it('should not set user when registration requires manual login', async () => {
+      const { result } = renderHook(() => useAuth(), { wrapper })
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false)
+      })
+
+      ;(global.fetch as jest.Mock).mockImplementationOnce((url) => {
+        if (url === '/api/auth/register') {
+          return Promise.resolve({
+            ok: true,
+            status: 202,
+            json: jest.fn().mockResolvedValue({
+              message: 'User created successfully. Please log in.',
+              requiresManualLogin: true,
+              user: {
+                id: 'new-user-id',
+                email: 'newuser@example.com',
+                role: UserRole.VIEWER,
+                profile: {},
               },
             }),
           })
@@ -195,16 +237,17 @@ describe('useAuth Hook', () => {
       })
 
       await act(async () => {
-        await result.current.register({
+        const out = await result.current.register({
           email: 'newuser@example.com',
           password: 'password123',
           first_name: 'Test',
           last_name: 'User',
         })
+        expect(out.requiresManualLogin).toBe(true)
       })
 
-      expect(result.current.user).toBeDefined()
-      expect(result.current.user?.email).toBe('newuser@example.com')
+      expect(result.current.user).toBeNull()
+      expect(result.current.session).toBeNull()
     })
 
     it('should handle registration errors', async () => {

--- a/__tests__/lib/session-management.test.ts
+++ b/__tests__/lib/session-management.test.ts
@@ -3,10 +3,10 @@ import {
   createEnhancedSession,
   normalizeClientIpForInet
 } from '@/lib/session-management'
-import { getSupabaseAdmin } from '@/lib/supabase'
+import { createSupabaseServiceRoleClient } from '@/lib/supabase'
 
 jest.mock('@/lib/supabase', () => ({
-  getSupabaseAdmin: jest.fn()
+  createSupabaseServiceRoleClient: jest.fn()
 }))
 
 function requestWithForwardedFor(ip: string) {
@@ -37,7 +37,7 @@ describe('createEnhancedSession', () => {
   })
 
   it('throws when user_sessions insert returns an error', async () => {
-    ;(getSupabaseAdmin as jest.Mock).mockReturnValue({
+    ;(createSupabaseServiceRoleClient as jest.Mock).mockReturnValue({
       from: jest.fn(() => ({
         insert: jest
           .fn()
@@ -58,7 +58,7 @@ describe('createEnhancedSession', () => {
   })
 
   it('returns session id when insert succeeds', async () => {
-    ;(getSupabaseAdmin as jest.Mock).mockReturnValue({
+    ;(createSupabaseServiceRoleClient as jest.Mock).mockReturnValue({
       from: jest.fn(() => ({
         insert: jest.fn().mockResolvedValue({ error: null }),
         select: jest.fn(() => ({

--- a/__tests__/lib/session-management.test.ts
+++ b/__tests__/lib/session-management.test.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from 'next/server'
 import {
+  buildUserSessionInsertRow,
   createEnhancedSession,
   normalizeClientIpForInet
 } from '@/lib/session-management'
@@ -28,6 +29,33 @@ describe('normalizeClientIpForInet', () => {
   it('returns valid IPv4 and IPv6 literals', () => {
     expect(normalizeClientIpForInet('203.0.113.10')).toBe('203.0.113.10')
     expect(normalizeClientIpForInet('2001:db8::1')).toBe('2001:db8::1')
+  })
+})
+
+describe('buildUserSessionInsertRow', () => {
+  it('only includes columns that exist on user_sessions (no token fields)', () => {
+    const row = buildUserSessionInsertRow({
+      session_id: 'sess_1',
+      user_id: 'user-1',
+      ip_address: '203.0.113.1',
+      user_agent: 'jest',
+      expires_at: '2026-01-01T00:00:00.000Z',
+    })
+    expect(Object.keys(row).sort()).toEqual(
+      [
+        'created_at',
+        'expires_at',
+        'ip_address',
+        'is_active',
+        'last_activity',
+        'session_id',
+        'user_agent',
+        'user_id',
+      ].sort()
+    )
+    expect(row).not.toHaveProperty('access_token')
+    expect(row).not.toHaveProperty('refresh_token')
+    expect(row).not.toHaveProperty('updated_at')
   })
 })
 

--- a/__tests__/lib/session-management.test.ts
+++ b/__tests__/lib/session-management.test.ts
@@ -1,0 +1,78 @@
+import { NextRequest } from 'next/server'
+import {
+  createEnhancedSession,
+  normalizeClientIpForInet
+} from '@/lib/session-management'
+import { getSupabaseAdmin } from '@/lib/supabase'
+
+jest.mock('@/lib/supabase', () => ({
+  getSupabaseAdmin: jest.fn()
+}))
+
+function requestWithForwardedFor(ip: string) {
+  return new NextRequest('http://localhost/', {
+    headers: new Headers({
+      'x-forwarded-for': ip,
+      'user-agent': 'jest-test'
+    })
+  })
+}
+
+describe('normalizeClientIpForInet', () => {
+  it('returns null for unknown, empty, and invalid values', () => {
+    expect(normalizeClientIpForInet('unknown')).toBeNull()
+    expect(normalizeClientIpForInet('')).toBeNull()
+    expect(normalizeClientIpForInet('not-an-ip')).toBeNull()
+  })
+
+  it('returns valid IPv4 and IPv6 literals', () => {
+    expect(normalizeClientIpForInet('203.0.113.10')).toBe('203.0.113.10')
+    expect(normalizeClientIpForInet('2001:db8::1')).toBe('2001:db8::1')
+  })
+})
+
+describe('createEnhancedSession', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('throws when user_sessions insert returns an error', async () => {
+    ;(getSupabaseAdmin as jest.Mock).mockReturnValue({
+      from: jest.fn(() => ({
+        insert: jest
+          .fn()
+          .mockResolvedValue({ error: { message: 'invalid input syntax for type inet' } }),
+        select: jest.fn(() => ({
+          eq: jest.fn(() => ({
+            eq: jest.fn().mockResolvedValue({ data: [], error: null })
+          }))
+        }))
+      }))
+    })
+
+    const req = requestWithForwardedFor('203.0.113.1')
+
+    await expect(createEnhancedSession('user-id-1', req)).rejects.toThrow(
+      'user_sessions insert failed'
+    )
+  })
+
+  it('returns session id when insert succeeds', async () => {
+    ;(getSupabaseAdmin as jest.Mock).mockReturnValue({
+      from: jest.fn(() => ({
+        insert: jest.fn().mockResolvedValue({ error: null }),
+        select: jest.fn(() => ({
+          eq: jest.fn(() => ({
+            eq: jest.fn().mockResolvedValue({ data: [], error: null })
+          }))
+        }))
+      }))
+    })
+
+    const req = requestWithForwardedFor('203.0.113.2')
+
+    const id = await createEnhancedSession('user-id-2', req, 'sess_fixed_id_for_test')
+
+    expect(id).toBe('sess_fixed_id_for_test')
+  })
+})

--- a/app/api/account-settings/delete-account/route.ts
+++ b/app/api/account-settings/delete-account/route.ts
@@ -58,7 +58,7 @@ export async function POST(request: NextRequest) {
     // Include user_credentials so X API, Twitter, Apify, and other credentials are removed.
     const tablesToDelete = [
       'audit_logs',
-      'permission_audit_logs',
+      'permission_audit_log',
       'user_sessions',
       'account_settings',
       'user_profiles',

--- a/app/api/account-settings/route.ts
+++ b/app/api/account-settings/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
-import { getSupabaseAdmin } from '@/lib/supabase';
+import { createSupabaseServiceRoleClient, getSupabaseAdmin } from '@/lib/supabase';
 import { getCurrentUser } from '@/lib/auth-utils';
 import { logAuditEvent } from '@/lib/auth-utils';
 import { AuthErrorType } from '@/lib/auth-types';
@@ -114,8 +114,8 @@ export async function GET(request: NextRequest) {
       updated_at: '',
     };
 
-    // Get active sessions
-    const { data: sessions, error: sessionsError } = await supabaseAdmin
+    // Get active sessions (service-role client: avoids user JWT on shared admin client overriding RLS)
+    const { data: sessions, error: sessionsError } = await createSupabaseServiceRoleClient()
       .from('user_sessions')
       .select('*')
       .eq('user_id', user.id)

--- a/app/api/account-settings/sessions/route.ts
+++ b/app/api/account-settings/sessions/route.ts
@@ -76,14 +76,18 @@ export async function DELETE(request: NextRequest) {
       return NextResponse.json({ error: 'Cannot revoke current session' }, { status: 400 });
     }
 
-    // Revoke the session
-    const { error: deleteError } = await db
+    // Revoke the session (enforce ownership on delete for service-role client)
+    const { error: deleteError, count } = await db
       .from('user_sessions')
-      .delete()
-      .eq('id', validatedData.session_id);
+      .delete({ count: 'exact' })
+      .eq('id', validatedData.session_id)
+      .eq('user_id', user.id);
 
     if (deleteError) {
       return NextResponse.json({ error: 'Failed to revoke session' }, { status: 500 });
+    }
+    if (count === 0) {
+      return NextResponse.json({ error: 'Session not found or access denied' }, { status: 404 });
     }
 
     // Log audit event

--- a/app/api/account-settings/sessions/route.ts
+++ b/app/api/account-settings/sessions/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
-import { getSupabaseAdmin } from '@/lib/supabase';
+import { createSupabaseServiceRoleClient } from '@/lib/supabase';
 import { getCurrentUser } from '@/lib/auth-utils';
 import { logAuditEvent } from '@/lib/auth-utils';
 import { AuthErrorType } from '@/lib/auth-types';
@@ -17,9 +17,9 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const supabaseAdmin = getSupabaseAdmin();
+    const db = createSupabaseServiceRoleClient();
     // Get all active sessions for the user
-    const { data: sessions, error } = await supabaseAdmin
+    const { data: sessions, error } = await db
       .from('user_sessions')
       .select('*')
       .eq('user_id', user.id)
@@ -58,9 +58,9 @@ export async function DELETE(request: NextRequest) {
     const body = await request.json();
     const validatedData = RevokeSessionSchema.parse(body);
 
-    const supabaseAdmin = getSupabaseAdmin();
+    const db = createSupabaseServiceRoleClient();
     // Verify the session belongs to the user
-    const { data: session, error: fetchError } = await supabaseAdmin
+    const { data: session, error: fetchError } = await db
       .from('user_sessions')
       .select('*')
       .eq('id', validatedData.session_id)
@@ -77,7 +77,7 @@ export async function DELETE(request: NextRequest) {
     }
 
     // Revoke the session
-    const { error: deleteError } = await supabaseAdmin
+    const { error: deleteError } = await db
       .from('user_sessions')
       .delete()
       .eq('id', validatedData.session_id);

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -110,37 +110,40 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    // Create session record - use direct approach for reliability
+    // Create session record - required so getCurrentUser() can resolve the user
     const sessionId = 'sess_' + Date.now() + '_' + Math.random().toString(36).substr(2, 9)
-    
-    try {
-      const { error: sessionError } = await getSupabaseAdmin()
-        .from('user_sessions')
-        .insert({
-          session_id: sessionId,
-          user_id: data.user.id,
-          access_token: data.session.access_token,
-          refresh_token: data.session.refresh_token,
-          expires_at: new Date(data.session.expires_at * 1000).toISOString(),
-          created_at: new Date().toISOString(),
-          updated_at: new Date().toISOString(),
-          last_activity: new Date().toISOString(),
-          is_active: true,
-          ip_address:
-            (req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
-             req.headers.get('x-real-ip') ||
-             'unknown'),
-          user_agent: req.headers.get('user-agent') || 'unknown',
-          device_info: {}
-        })
-      
-      if (sessionError) {
-        console.error('Failed to create session:', sessionError)
-      } else {
-        console.log('✅ Session created successfully:', sessionId)
-      }
-    } catch (sessionError) {
+
+    const { error: sessionError } = await getSupabaseAdmin()
+      .from('user_sessions')
+      .insert({
+        session_id: sessionId,
+        user_id: data.user.id,
+        access_token: data.session.access_token,
+        refresh_token: data.session.refresh_token,
+        expires_at: new Date(data.session.expires_at * 1000).toISOString(),
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        last_activity: new Date().toISOString(),
+        is_active: true,
+        ip_address:
+          (req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+           req.headers.get('x-real-ip') ||
+           'unknown'),
+        user_agent: req.headers.get('user-agent') || 'unknown',
+        device_info: {}
+      })
+
+    if (sessionError) {
       console.error('Failed to create session:', sessionError)
+      return NextResponse.json(
+        {
+          error: createAuthError(
+            AuthErrorType.NETWORK_ERROR,
+            'Session could not be created. Please try again or contact support.'
+          )
+        },
+        { status: 500 }
+      )
     }
 
     // Get user role from database (default to VIEWER if not set)

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -111,29 +111,10 @@ export async function POST(request: NextRequest) {
     }
 
     // Create session record - required so getCurrentUser() can resolve the user
-    const sessionId = 'sess_' + Date.now() + '_' + Math.random().toString(36).substr(2, 9)
-
-    const { error: sessionError } = await getSupabaseAdmin()
-      .from('user_sessions')
-      .insert({
-        session_id: sessionId,
-        user_id: data.user.id,
-        access_token: data.session.access_token,
-        refresh_token: data.session.refresh_token,
-        expires_at: new Date(data.session.expires_at * 1000).toISOString(),
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-        last_activity: new Date().toISOString(),
-        is_active: true,
-        ip_address:
-          (req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
-           req.headers.get('x-real-ip') ||
-           'unknown'),
-        user_agent: req.headers.get('user-agent') || 'unknown',
-        device_info: {}
-      })
-
-    if (sessionError) {
+    let sessionId: string
+    try {
+      sessionId = await createUserSession(data.user.id, data.session, req)
+    } catch (sessionError) {
       console.error('Failed to create session:', sessionError)
       return NextResponse.json(
         {

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getSupabaseAdmin } from '@/lib/supabase'
+import { getSupabaseAdmin, getSupabaseServiceKeyMisconfigurationMessage } from '@/lib/supabase'
 import { 
   LoginRequest, 
   AuthError, 
@@ -111,17 +111,32 @@ export async function POST(request: NextRequest) {
     }
 
     // Create session record - required so getCurrentUser() can resolve the user
+    const keyMisconfig = getSupabaseServiceKeyMisconfigurationMessage()
+    if (keyMisconfig) {
+      return NextResponse.json(
+        { error: createAuthError(AuthErrorType.NETWORK_ERROR, keyMisconfig) },
+        { status: 500 }
+      )
+    }
+
     let sessionId: string
     try {
       sessionId = await createUserSession(data.user.id, data.session, req)
     } catch (sessionError) {
       console.error('Failed to create session:', sessionError)
+      const msg =
+        sessionError instanceof Error ? sessionError.message : String(sessionError)
+      const rls =
+        msg.includes('row-level security') ||
+        msg.includes('violates row-level security') ||
+        msg.includes('42501')
+      const detail = rls
+        ? (getSupabaseServiceKeyMisconfigurationMessage() ??
+          'Session row could not be saved (RLS). Confirm SUPABASE_SERVICE_ROLE_KEY is the service_role secret, not the anon key.')
+        : 'Session could not be created. Please try again or contact support.'
       return NextResponse.json(
         {
-          error: createAuthError(
-            AuthErrorType.NETWORK_ERROR,
-            'Session could not be created. Please try again or contact support.'
-          )
+          error: createAuthError(AuthErrorType.NETWORK_ERROR, detail)
         },
         { status: 500 }
       )

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getSupabaseAdmin } from '@/lib/supabase'
+import { getSupabaseAdmin, getSupabaseServiceKeyMisconfigurationMessage } from '@/lib/supabase'
 import { 
   RegisterRequest, 
   AuthError, 
@@ -135,7 +135,34 @@ export async function POST(request: NextRequest) {
     }
 
     // Create session in database
-    const sessionId = await createUserSession(data.user.id, signInData.session, request)
+    const keyMisconfig = getSupabaseServiceKeyMisconfigurationMessage()
+    if (keyMisconfig) {
+      return NextResponse.json(
+        { error: createAuthError(AuthErrorType.NETWORK_ERROR, keyMisconfig) },
+        { status: 500 }
+      )
+    }
+
+    let sessionId: string
+    try {
+      sessionId = await createUserSession(data.user.id, signInData.session, request)
+    } catch (sessionError) {
+      console.error('Failed to create session:', sessionError)
+      const msg =
+        sessionError instanceof Error ? sessionError.message : String(sessionError)
+      const rls =
+        msg.includes('row-level security') ||
+        msg.includes('violates row-level security') ||
+        msg.includes('42501')
+      const detail = rls
+        ? (getSupabaseServiceKeyMisconfigurationMessage() ??
+          'Use the service_role secret for SUPABASE_SERVICE_ROLE_KEY (Supabase Dashboard → Project Settings → API), not the anon key.')
+        : 'Session could not be created. Please try again or contact support.'
+      return NextResponse.json(
+        { error: createAuthError(AuthErrorType.NETWORK_ERROR, detail) },
+        { status: 500 }
+      )
+    }
 
     // Log successful registration
     await logAuditEvent(

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -130,15 +130,19 @@ export async function POST(request: NextRequest) {
 
     if (signInError || !signInData.session) {
       // User created but couldn't sign in - they'll need to login manually
-      return NextResponse.json({
-        message: 'User created successfully. Please log in.',
-        user: {
-          id: data.user.id,
-          email: data.user.email,
-          role: UserRole.VIEWER,
-          profile
-        }
-      })
+      return NextResponse.json(
+        {
+          message: 'User created successfully. Please log in.',
+          requiresManualLogin: true,
+          user: {
+            id: data.user.id,
+            email: data.user.email,
+            role: UserRole.VIEWER,
+            profile
+          }
+        },
+        { status: 202 }
+      )
     }
 
     // Create session in database
@@ -147,15 +151,19 @@ export async function POST(request: NextRequest) {
       sessionId = await createUserSession(data.user.id, signInData.session, request)
     } catch (sessionError) {
       console.error('Failed to create session after registration (user/profile already created):', sessionError)
-      return NextResponse.json({
-        message: 'User created successfully. Please log in.',
-        user: {
-          id: data.user.id,
-          email: data.user.email,
-          role: UserRole.VIEWER,
-          profile
-        }
-      })
+      return NextResponse.json(
+        {
+          message: 'User created successfully. Please log in.',
+          requiresManualLogin: true,
+          user: {
+            id: data.user.id,
+            email: data.user.email,
+            role: UserRole.VIEWER,
+            profile
+          }
+        },
+        { status: 202 }
+      )
     }
 
     // Log successful registration

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -7,7 +7,6 @@ import {
   UserRole 
 } from '@/lib/auth-types'
 import { 
-  setAuthCookiesResponse, 
   createUserProfile, 
   logAuditEvent,
   createAuthError,
@@ -33,6 +32,14 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(
         { error: createAuthError(AuthErrorType.INVALID_CREDENTIALS, 'Password must be at least 8 characters long') },
         { status: 400 }
+      )
+    }
+
+    const keyMisconfigEarly = getSupabaseServiceKeyMisconfigurationMessage()
+    if (keyMisconfigEarly) {
+      return NextResponse.json(
+        { error: createAuthError(AuthErrorType.NETWORK_ERROR, keyMisconfigEarly) },
+        { status: 503 }
       )
     }
 
@@ -135,33 +142,20 @@ export async function POST(request: NextRequest) {
     }
 
     // Create session in database
-    const keyMisconfig = getSupabaseServiceKeyMisconfigurationMessage()
-    if (keyMisconfig) {
-      return NextResponse.json(
-        { error: createAuthError(AuthErrorType.NETWORK_ERROR, keyMisconfig) },
-        { status: 500 }
-      )
-    }
-
     let sessionId: string
     try {
       sessionId = await createUserSession(data.user.id, signInData.session, request)
     } catch (sessionError) {
-      console.error('Failed to create session:', sessionError)
-      const msg =
-        sessionError instanceof Error ? sessionError.message : String(sessionError)
-      const rls =
-        msg.includes('row-level security') ||
-        msg.includes('violates row-level security') ||
-        msg.includes('42501')
-      const detail = rls
-        ? (getSupabaseServiceKeyMisconfigurationMessage() ??
-          'Use the service_role secret for SUPABASE_SERVICE_ROLE_KEY (Supabase Dashboard → Project Settings → API), not the anon key.')
-        : 'Session could not be created. Please try again or contact support.'
-      return NextResponse.json(
-        { error: createAuthError(AuthErrorType.NETWORK_ERROR, detail) },
-        { status: 500 }
-      )
+      console.error('Failed to create session after registration (user/profile already created):', sessionError)
+      return NextResponse.json({
+        message: 'User created successfully. Please log in.',
+        user: {
+          id: data.user.id,
+          email: data.user.email,
+          role: UserRole.VIEWER,
+          profile
+        }
+      })
     }
 
     // Log successful registration

--- a/app/api/onboarding/route.ts
+++ b/app/api/onboarding/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getSupabaseAdmin } from '@/lib/supabase'
+import { createSupabaseServiceRoleClient } from '@/lib/supabase'
 import { getCurrentUser, createAuthError } from '@/lib/auth-utils'
 import { AuthErrorType } from '@/lib/auth-types'
 import { ONBOARDING_STEPS } from '@/lib/onboarding'
@@ -18,8 +18,8 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const supabaseAdmin = getSupabaseAdmin()
-    const { data: profile, error } = await supabaseAdmin
+    const db = createSupabaseServiceRoleClient()
+    const { data: profile, error } = await db
       .from('user_profiles')
       .select('onboarding_step, onboarding_completed_at, tutorial_completed_at, show_contextual_tooltips')
       .eq('user_id', user.id)
@@ -82,10 +82,10 @@ export async function PATCH(request: NextRequest) {
 
   try {
     const body = await request.json().catch(() => ({}))
-    const supabaseAdmin = getSupabaseAdmin()
+    const db = createSupabaseServiceRoleClient()
 
     if (UpdateSchema.resetTutorial(body.resetTutorial)) {
-      const { error } = await supabaseAdmin
+      const { error } = await db
         .from('user_profiles')
         .upsert(
           {
@@ -119,7 +119,7 @@ export async function PATCH(request: NextRequest) {
       return NextResponse.json({ success: true })
     }
 
-    const { error } = await supabaseAdmin
+    const { error } = await db
       .from('user_profiles')
       .upsert({ user_id: user.id, ...updates }, { onConflict: 'user_id' })
 

--- a/app/api/test/route.ts
+++ b/app/api/test/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createSupabaseServiceRoleClient, getSupabaseAdmin } from '@/lib/supabase'
+import { createSupabaseServiceRoleClient } from '@/lib/supabase'
 import { isAdmin } from '@/lib/admin-auth'
 
 /**
@@ -12,7 +12,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
     }
 
-    const supabase = getSupabaseAdmin()
+    const supabase = createSupabaseServiceRoleClient()
 
     console.log('🔍 Testing Supabase connection...')
 
@@ -39,7 +39,7 @@ export async function GET(request: NextRequest) {
     }
 
     console.log('🔍 Testing user_sessions table...')
-    const { data: sessions, error: sessionsError } = await createSupabaseServiceRoleClient()
+    const { data: sessions, error: sessionsError } = await supabase
       .from('user_sessions')
       .select('id')
       .limit(1)

--- a/app/api/test/route.ts
+++ b/app/api/test/route.ts
@@ -1,69 +1,65 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServiceRoleClient, getSupabaseAdmin } from '@/lib/supabase'
+import { isAdmin } from '@/lib/admin-auth'
 
+/**
+ * DB connectivity diagnostics. In production, admin session or ADMIN_RECOVERY_TOKEN only;
+ * in development, open for local setup (still avoids returning raw Supabase payloads).
+ */
 export async function GET(request: NextRequest) {
   try {
+    if (process.env.NODE_ENV === 'production' && !(await isAdmin(request))) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
     const supabase = getSupabaseAdmin()
-    
-    // Test 1: Check if we can connect to Supabase
+
     console.log('🔍 Testing Supabase connection...')
-    
-    // Test 2: Check if user_profiles table exists
+
     console.log('🔍 Testing user_profiles table...')
     const { data: profiles, error: profilesError } = await supabase
       .from('user_profiles')
       .select('id')
       .limit(1)
-    
+
     if (profilesError) {
-      return NextResponse.json({ 
-        error: 'user_profiles table error', 
-        details: profilesError 
-      }, { status: 500 })
+      console.error('Test endpoint user_profiles:', profilesError)
+      return NextResponse.json({ error: 'user_profiles check failed' }, { status: 500 })
     }
-    
-    // Test 3: Check if user_roles table exists
+
     console.log('🔍 Testing user_roles table...')
     const { data: roles, error: rolesError } = await supabase
       .from('user_roles')
       .select('id')
       .limit(1)
-    
+
     if (rolesError) {
-      return NextResponse.json({ 
-        error: 'user_roles table error', 
-        details: rolesError 
-      }, { status: 500 })
+      console.error('Test endpoint user_roles:', rolesError)
+      return NextResponse.json({ error: 'user_roles check failed' }, { status: 500 })
     }
-    
-    // Test 4: Check if user_sessions table exists
+
     console.log('🔍 Testing user_sessions table...')
     const { data: sessions, error: sessionsError } = await createSupabaseServiceRoleClient()
       .from('user_sessions')
       .select('id')
       .limit(1)
-    
+
     if (sessionsError) {
-      return NextResponse.json({ 
-        error: 'user_sessions table error', 
-        details: sessionsError 
-      }, { status: 500 })
+      console.error('Test endpoint user_sessions:', sessionsError)
+      return NextResponse.json({ error: 'user_sessions check failed' }, { status: 500 })
     }
-    
-    // Test 5: Check if account_settings table exists
+
     console.log('🔍 Testing account_settings table...')
     const { data: settings, error: settingsError } = await supabase
       .from('account_settings')
       .select('id')
       .limit(1)
-    
+
     if (settingsError) {
-      return NextResponse.json({ 
-        error: 'account_settings table error', 
-        details: settingsError 
-      }, { status: 500 })
+      console.error('Test endpoint account_settings:', settingsError)
+      return NextResponse.json({ error: 'account_settings check failed' }, { status: 500 })
     }
-    
+
     return NextResponse.json({
       success: true,
       message: 'All database tables are accessible',
@@ -71,15 +67,11 @@ export async function GET(request: NextRequest) {
         user_profiles: profiles ? 'accessible' : 'error',
         user_roles: roles ? 'accessible' : 'error',
         user_sessions: sessions ? 'accessible' : 'error',
-        account_settings: settings ? 'accessible' : 'error'
-      }
+        account_settings: settings ? 'accessible' : 'error',
+      },
     })
-    
   } catch (error) {
     console.error('Test endpoint error:', error)
-    return NextResponse.json({ 
-      error: 'Test failed', 
-      details: error instanceof Error ? error.message : 'Unknown error'
-    }, { status: 500 })
+    return NextResponse.json({ error: 'Test failed' }, { status: 500 })
   }
 }

--- a/app/api/test/route.ts
+++ b/app/api/test/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getSupabaseAdmin } from '@/lib/supabase'
+import { createSupabaseServiceRoleClient, getSupabaseAdmin } from '@/lib/supabase'
 
 export async function GET(request: NextRequest) {
   try {
@@ -38,7 +38,7 @@ export async function GET(request: NextRequest) {
     
     // Test 4: Check if user_sessions table exists
     console.log('🔍 Testing user_sessions table...')
-    const { data: sessions, error: sessionsError } = await supabase
+    const { data: sessions, error: sessionsError } = await createSupabaseServiceRoleClient()
       .from('user_sessions')
       .select('id')
       .limit(1)

--- a/components/auth/register-form.tsx
+++ b/components/auth/register-form.tsx
@@ -71,7 +71,12 @@ export function RegisterForm({ onSuccess, onSwitchToLogin }: RegisterFormProps) 
 
   const onSubmit = async (data: RegisterFormData) => {
     try {
-      await registerUser(data)
+      const outcome = await registerUser(data)
+      if (outcome.requiresManualLogin) {
+        toast.info('Account created. Please sign in with your email and password.')
+        router.push('/login')
+        return
+      }
       toast.success('Registration successful! Welcome to the platform.')
       onSuccess?.()
       // Redirect to home so onboarding check runs; user is then sent to /onboarding or /dashboard

--- a/hooks/use-auth.tsx
+++ b/hooks/use-auth.tsx
@@ -3,9 +3,11 @@
 import React, { createContext, useContext, useEffect, useRef, useState, ReactNode } from 'react'
 import { AuthState, AuthUser, LoginRequest, RegisterRequest } from '@/lib/auth-types'
 
+export type RegisterResult = { requiresManualLogin?: boolean }
+
 interface AuthContextType extends AuthState {
   login: (credentials: LoginRequest) => Promise<void>
-  register: (userData: RegisterRequest) => Promise<void>
+  register: (userData: RegisterRequest) => Promise<RegisterResult>
   logout: () => Promise<void>
   refreshSession: () => Promise<boolean>
 }
@@ -165,7 +167,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
     }
   }
 
-  const register = async (userData: RegisterRequest) => {
+  const register = async (userData: RegisterRequest): Promise<RegisterResult> => {
     try {
       setState(prev => ({ ...prev, loading: true, error: null }))
       
@@ -211,12 +213,18 @@ export function AuthProvider({ children }: AuthProviderProps) {
         throw new Error(errorMessage)
       }
 
+      if (data.requiresManualLogin) {
+        setState(setUnauthenticatedState())
+        return { requiresManualLogin: true }
+      }
+
       setState({
         user: data.user,
         session: data.session,
         loading: false,
         error: null
       })
+      return {}
     } catch (error) {
       console.error('Registration error:', error)
       setState(prev => ({

--- a/hooks/use-profile.tsx
+++ b/hooks/use-profile.tsx
@@ -31,6 +31,8 @@ interface AvatarUploadData {
 
 /** Module-scoped dedup: one in-flight profile fetch per user across all useProfile() instances */
 const profileFetchInflight = new Map<string, Promise<ProfileData | undefined>>();
+/** Module-scoped 401 blocker: prevent retry loops per user across all useProfile() instances */
+const profile401BlockByUserId = new Map<string, boolean>();
 
 export function useProfile() {
   const { user, refreshSession } = useAuth();
@@ -38,15 +40,17 @@ export function useProfile() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const lastUserIdRef = useRef<string | null>(null);
-  /** Block profile fetch after 401 until user identity changes (stops retry loop) */
-  const profile401BlockRef = useRef(false);
 
   // Reset stored profile and 401 block when auth user changes so stale async results cannot overwrite state
   useEffect(() => {
-    const userId = user?.id ?? null;
-    if (userId !== lastUserIdRef.current) {
-      lastUserIdRef.current = userId;
-      profile401BlockRef.current = false;
+    const newUserId = user?.id ?? null;
+    const previousUserId = lastUserIdRef.current;
+    if (newUserId !== previousUserId) {
+      // Clear any 401 block for the previous user id so new sessions aren't blocked
+      if (previousUserId) {
+        profile401BlockByUserId.delete(previousUserId);
+      }
+      lastUserIdRef.current = newUserId;
       setProfile(null);
       setError(null);
     }
@@ -57,39 +61,50 @@ export function useProfile() {
    */
   const fetchProfile = useCallback(async () => {
     if (!user) return;
-    if (profile401BlockRef.current) return;
+    if (profile401BlockByUserId.get(user.id)) return;
 
     const existing = profileFetchInflight.get(user.id);
     if (existing) {
       setLoading(true);
       try {
+        setError(null);
+        const startedFor = user.id;
         const data = await existing;
-        if (lastUserIdRef.current === (user?.id ?? null)) {
+        if (lastUserIdRef.current === (user?.id ?? null) && lastUserIdRef.current === startedFor) {
           setProfile(data?.profile ?? null);
         }
         return data;
+      } catch (err) {
+        if (lastUserIdRef.current === (user?.id ?? null)) {
+          const errorMessage = err instanceof Error ? err.message : 'Unknown error';
+          setError(errorMessage);
+        }
+        throw err;
       } finally {
-        setLoading(false);
+        if (lastUserIdRef.current === (user?.id ?? null)) {
+          setLoading(false);
+        }
       }
     }
 
-    const promise = (async (): Promise<ProfileData | undefined> => {
-      setLoading(true);
-      setError(null);
+    const startedFor = user.id;
+    setLoading(true);
+    setError(null);
 
+    const promise = (async (): Promise<ProfileData | undefined> => {
       try {
         const response = await fetch('/api/profile', { credentials: 'include' });
 
         if (response.status === 401) {
-          profile401BlockRef.current = true;
+          profile401BlockByUserId.set(user.id, true);
           setError('Session expired');
           const restored = await refreshSession();
           if (restored) {
-            profile401BlockRef.current = false;
+            profile401BlockByUserId.set(user.id, false);
             setError(null);
             const retryResponse = await fetch('/api/profile', { credentials: 'include' });
             if (retryResponse.status === 401) {
-              profile401BlockRef.current = true;
+              profile401BlockByUserId.set(user.id, true);
               setError('Session expired');
               return undefined;
             }
@@ -120,13 +135,20 @@ export function useProfile() {
           setError(errorMessage);
         }
         throw err;
-      } finally {
-        setLoading(false);
-        profileFetchInflight.delete(user.id);
       }
     })();
 
-    profileFetchInflight.set(user.id, promise);
+    profileFetchInflight.set(startedFor, promise);
+    promise.finally(() => {
+      if (lastUserIdRef.current === (user?.id ?? null) && lastUserIdRef.current === startedFor) {
+        setLoading(false);
+      }
+      const current = profileFetchInflight.get(startedFor);
+      if (current === promise) {
+        profileFetchInflight.delete(startedFor);
+      }
+    });
+
     return promise;
   }, [user, refreshSession]);
 

--- a/hooks/use-profile.tsx
+++ b/hooks/use-profile.tsx
@@ -65,9 +65,11 @@ export function useProfile() {
     const newUserId = user?.id ?? null;
     const previousUserId = lastUserIdRef.current;
     if (newUserId !== previousUserId) {
-      // Clear any 401 block for the previous user id so new sessions aren't blocked
       if (previousUserId) {
         profile401BlockByUserId.delete(previousUserId);
+      }
+      if (newUserId) {
+        profile401BlockByUserId.delete(newUserId);
       }
       lastUserIdRef.current = newUserId;
       setProfile(null);
@@ -81,14 +83,6 @@ export function useProfile() {
    */
   const fetchProfile = useCallback(async () => {
     if (!user) return;
-    const blockUntil = profile401BlockByUserId.get(user.id);
-    const now = Date.now();
-    if (blockUntil && blockUntil > now) {
-      return;
-    }
-    if (blockUntil && blockUntil <= now) {
-      profile401BlockByUserId.delete(user.id);
-    }
 
     const existing = profileFetchInflight.get(user.id);
     if (existing) {
@@ -114,6 +108,15 @@ export function useProfile() {
       }
     }
 
+    const blockUntil = profile401BlockByUserId.get(user.id);
+    const now = Date.now();
+    if (blockUntil && blockUntil > now) {
+      return;
+    }
+    if (blockUntil && blockUntil <= now) {
+      profile401BlockByUserId.delete(user.id);
+    }
+
     const startedFor = user.id;
     setLoading(true);
     setError(null);
@@ -123,14 +126,22 @@ export function useProfile() {
         const response = await fetch('/api/profile', { credentials: 'include' });
 
         if (response.status === 401) {
-          // Set or extend a cooldown to avoid tight 401 retry loops.
+          if (lastUserIdRef.current !== startedFor) {
+            return undefined;
+          }
           scheduleProfile401Backoff(user.id);
           setError('Session expired');
           const restored = await refreshSession();
+          if (lastUserIdRef.current !== startedFor) {
+            return undefined;
+          }
           if (restored) {
             profile401BlockByUserId.delete(user.id);
             setError(null);
             const retryResponse = await fetch('/api/profile', { credentials: 'include' });
+            if (lastUserIdRef.current !== startedFor) {
+              return undefined;
+            }
             if (retryResponse.status === 401) {
               scheduleProfile401Backoff(user.id);
               setError('Session expired');
@@ -140,7 +151,7 @@ export function useProfile() {
               throw new Error('Failed to fetch profile');
             }
             const retryData: ProfileData = await retryResponse.json();
-            if (lastUserIdRef.current === user.id) {
+            if (lastUserIdRef.current === startedFor) {
               setProfile(retryData.profile);
             }
             return retryData;
@@ -153,13 +164,13 @@ export function useProfile() {
         }
 
         const data: ProfileData = await response.json();
-        if (lastUserIdRef.current === user.id) {
+        if (lastUserIdRef.current === startedFor) {
           setProfile(data.profile);
         }
         return data;
       } catch (err) {
         const errorMessage = err instanceof Error ? err.message : 'Unknown error';
-        if (lastUserIdRef.current === (user?.id ?? null)) {
+        if (lastUserIdRef.current === startedFor) {
           setError(errorMessage);
         }
         throw err;

--- a/hooks/use-profile.tsx
+++ b/hooks/use-profile.tsx
@@ -31,8 +31,27 @@ interface AvatarUploadData {
 
 /** Module-scoped dedup: one in-flight profile fetch per user across all useProfile() instances */
 const profileFetchInflight = new Map<string, Promise<ProfileData | undefined>>();
-/** Module-scoped 401 blocker: prevent retry loops per user across all useProfile() instances */
-const profile401BlockByUserId = new Map<string, boolean>();
+/**
+ * Module-scoped 401 blocker: prevent retry loops per user across all useProfile() instances.
+ * Values are timestamps (in ms since epoch) indicating when the block expires.
+ */
+const profile401BlockByUserId = new Map<string, number>();
+
+const PROFILE_401_BASE_BACKOFF_MS = 30_000;
+const PROFILE_401_MAX_BACKOFF_MS = 5 * 60_000;
+
+function scheduleProfile401Backoff(userId: string) {
+  const now = Date.now();
+  const currentExpiry = profile401BlockByUserId.get(userId);
+
+  let nextBackoffMs = PROFILE_401_BASE_BACKOFF_MS;
+  if (currentExpiry && currentExpiry > now) {
+    const remainingMs = currentExpiry - now;
+    nextBackoffMs = Math.min(remainingMs * 2, PROFILE_401_MAX_BACKOFF_MS);
+  }
+
+  profile401BlockByUserId.set(userId, now + nextBackoffMs);
+}
 
 export function useProfile() {
   const { user, refreshSession } = useAuth();
@@ -52,6 +71,7 @@ export function useProfile() {
       }
       lastUserIdRef.current = newUserId;
       setProfile(null);
+      setLoading(false);
       setError(null);
     }
   }, [user?.id]);
@@ -61,7 +81,14 @@ export function useProfile() {
    */
   const fetchProfile = useCallback(async () => {
     if (!user) return;
-    if (profile401BlockByUserId.get(user.id)) return;
+    const blockUntil = profile401BlockByUserId.get(user.id);
+    const now = Date.now();
+    if (blockUntil && blockUntil > now) {
+      return;
+    }
+    if (blockUntil && blockUntil <= now) {
+      profile401BlockByUserId.delete(user.id);
+    }
 
     const existing = profileFetchInflight.get(user.id);
     if (existing) {
@@ -96,15 +123,16 @@ export function useProfile() {
         const response = await fetch('/api/profile', { credentials: 'include' });
 
         if (response.status === 401) {
-          profile401BlockByUserId.set(user.id, true);
+          // Set or extend a cooldown to avoid tight 401 retry loops.
+          scheduleProfile401Backoff(user.id);
           setError('Session expired');
           const restored = await refreshSession();
           if (restored) {
-            profile401BlockByUserId.set(user.id, false);
+            profile401BlockByUserId.delete(user.id);
             setError(null);
             const retryResponse = await fetch('/api/profile', { credentials: 'include' });
             if (retryResponse.status === 401) {
-              profile401BlockByUserId.set(user.id, true);
+              scheduleProfile401Backoff(user.id);
               setError('Session expired');
               return undefined;
             }

--- a/lib/auth-utils.ts
+++ b/lib/auth-utils.ts
@@ -169,6 +169,16 @@ export async function refreshAccessToken(request: NextRequest): Promise<{ succes
       return { success: false }
     }
 
+    const { data: sessionRow } = await getSupabaseAdmin()
+      .from('user_sessions')
+      .select('is_active')
+      .eq('session_id', sessionId)
+      .single()
+
+    if (!sessionRow || sessionRow.is_active !== true) {
+      return { success: false }
+    }
+
     // Refresh the token with Supabase
     const { data, error } = await getSupabaseAdmin().auth.refreshSession({
       refresh_token: refreshToken
@@ -229,35 +239,30 @@ export async function createUserSession(
   } catch (error) {
     console.error('Error creating enhanced session, falling back to basic session:', error)
 
-    // Fallback to basic session creation that matches the historic login route
-    // behavior, including storing access/refresh tokens.
+    // Fallback: minimal row matching user_sessions schema (no token columns).
     const sessionId = generateSessionId()
     const now = new Date()
     const expiresAt = session?.expires_at
       ? new Date(session.expires_at * 1000)
       : new Date(now.getTime() + SESSION_CONFIG.sessionIdExpiry * 1000)
 
-    const sessionInfo = {
+    const fallbackSessionInfo = {
       session_id: sessionId,
       user_id: userId,
-      access_token: session?.access_token,
-      refresh_token: session?.refresh_token,
       expires_at: expiresAt.toISOString(),
       created_at: now.toISOString(),
-      updated_at: now.toISOString(),
       last_activity: now.toISOString(),
       is_active: true,
       ip_address:
         request.headers.get('x-forwarded-for') ||
         request.headers.get('x-real-ip') ||
         'unknown',
-      user_agent: request.headers.get('user-agent') || 'unknown',
-      device_info: {}
+      user_agent: request.headers.get('user-agent') || 'unknown'
     }
 
     const { error: insertError } = await getSupabaseAdmin()
       .from('user_sessions')
-      .insert(sessionInfo)
+      .insert(fallbackSessionInfo)
 
     if (insertError) {
       console.error('Failed to create basic session record:', insertError)

--- a/lib/auth-utils.ts
+++ b/lib/auth-utils.ts
@@ -843,7 +843,7 @@ async function logPermissionCheck(
     }
 
     await getSupabaseAdmin()
-      .from('permission_audit_logs')
+      .from('permission_audit_log')
       .insert(auditEntry)
   } catch (error) {
     console.error('Error logging permission check:', error)

--- a/lib/auth-utils.ts
+++ b/lib/auth-utils.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
-import { getSupabaseAdmin } from '@/lib/supabase'
+import { createSupabaseServiceRoleClient, getSupabaseAdmin } from '@/lib/supabase'
 import { 
   AuthUser, 
   UserRole, 
@@ -95,7 +95,7 @@ export async function getCurrentUser(request: NextRequest): Promise<AuthUser | n
     }
 
     // Check if session is still valid in our database
-    const { data: sessionInfo } = await getSupabaseAdmin()
+    const { data: sessionInfo } = await createSupabaseServiceRoleClient()
       .from('user_sessions')
       .select('*')
       .eq('session_id', sessionId)
@@ -117,7 +117,7 @@ export async function getCurrentUser(request: NextRequest): Promise<AuthUser | n
         console.error('[auth] Session repair failed:', repairError)
         return null
       }
-      const { data: repaired } = await getSupabaseAdmin()
+      const { data: repaired } = await createSupabaseServiceRoleClient()
         .from('user_sessions')
         .select('*')
         .eq('session_id', sessionId)
@@ -193,7 +193,7 @@ export async function refreshAccessToken(request: NextRequest): Promise<{ succes
       return { success: false }
     }
 
-    const { data: sessionRow } = await getSupabaseAdmin()
+    const { data: sessionRow } = await createSupabaseServiceRoleClient()
       .from('user_sessions')
       .select('is_active')
       .eq('session_id', sessionId)
@@ -287,7 +287,7 @@ export async function createUserSession(
       user_agent: request.headers.get('user-agent') || 'unknown'
     }
 
-    const { error: insertError } = await getSupabaseAdmin()
+    const { error: insertError } = await createSupabaseServiceRoleClient()
       .from('user_sessions')
       .insert(fallbackSessionInfo)
 
@@ -304,7 +304,7 @@ export async function createUserSession(
  * Update session activity timestamp
  */
 async function updateSessionActivity(sessionId: string): Promise<void> {
-  await getSupabaseAdmin()
+  await createSupabaseServiceRoleClient()
     .from('user_sessions')
     .update({ 
       last_activity: new Date().toISOString() 
@@ -320,7 +320,7 @@ async function updateSessionTokens(
   accessToken: string, 
   refreshToken: string
 ): Promise<void> {
-  await getSupabaseAdmin()
+  await createSupabaseServiceRoleClient()
     .from('user_sessions')
     .update({ 
       last_activity: new Date().toISOString(),
@@ -335,7 +335,7 @@ async function updateSessionTokens(
  * Deactivate a session
  */
 async function deactivateSession(sessionId: string): Promise<void> {
-  await getSupabaseAdmin()
+  await createSupabaseServiceRoleClient()
     .from('user_sessions')
     .update({ is_active: false })
     .eq('session_id', sessionId)
@@ -345,7 +345,7 @@ async function deactivateSession(sessionId: string): Promise<void> {
  * Deactivate all sessions for a user (except current one)
  */
 export async function deactivateOtherSessions(userId: string, currentSessionId: string): Promise<void> {
-  await getSupabaseAdmin()
+  await createSupabaseServiceRoleClient()
     .from('user_sessions')
     .update({ is_active: false })
     .eq('user_id', userId)
@@ -356,7 +356,7 @@ export async function deactivateOtherSessions(userId: string, currentSessionId: 
  * Get all active sessions for a user
  */
 export async function getUserSessions(userId: string): Promise<SessionInfo[]> {
-  const { data } = await getSupabaseAdmin()
+  const { data } = await createSupabaseServiceRoleClient()
     .from('user_sessions')
     .select('*')
     .eq('user_id', userId)

--- a/lib/auth-utils.ts
+++ b/lib/auth-utils.ts
@@ -175,8 +175,7 @@ export async function refreshAccessToken(request: NextRequest): Promise<{ succes
     })
 
     if (error || !data.session) {
-      // Refresh failed, clear cookies
-      clearAuthCookies()
+      // Refresh failed; do not clear cookies so client can retry or user can re-auth
       return { success: false }
     }
 

--- a/lib/auth-utils.ts
+++ b/lib/auth-utils.ts
@@ -15,7 +15,7 @@ import {
   PermissionAuditEntry
 } from '@/lib/auth-types'
 import { getCurrentUserDev } from '@/lib/auth-dev'
-import { normalizeClientIpForInet } from '@/lib/session-management'
+import { buildUserSessionInsertRow, normalizeClientIpForInet } from '@/lib/session-management'
 
 // Cookie names for authentication
 const AUTH_COOKIE_NAME = 'sb-auth-token'
@@ -152,15 +152,19 @@ export async function getCurrentUser(request: NextRequest): Promise<AuthUser | n
       await updateSessionActivity(sessionId)
     }
 
+    // Use a fresh service-role client so DB reads are not affected by a poisoned
+    // getSupabaseAdmin() singleton (e.g. after signInWithPassword on that client).
+    const db = createSupabaseServiceRoleClient()
+
     // Get user profile and role from database
-    const { data: profile } = await getSupabaseAdmin()
+    const { data: profile } = await db
       .from('user_profiles')
       .select('*')
       .eq('user_id', user.id)
       .single()
 
     // Get user role from database (default to VIEWER if not set)
-    const { data: roleData } = await getSupabaseAdmin()
+    const { data: roleData } = await db
       .from('user_roles')
       .select('role')
       .eq('user_id', user.id)
@@ -219,8 +223,8 @@ export async function refreshAccessToken(request: NextRequest): Promise<{ succes
       return { success: false }
     }
 
-    // Update session in database
-    await updateSessionTokens(sessionId, data.session.access_token, data.session.refresh_token)
+    // Bump session activity in DB (tokens stay in httpOnly cookies only; user_sessions has no token columns)
+    await updateSessionTokens(sessionId)
 
     // Set new cookies
     setAuthCookies(data.session)
@@ -276,16 +280,15 @@ export async function createUserSession(
       request.headers.get('cf-connecting-ip') ||
       'unknown'
 
-    const fallbackSessionInfo = {
+    const fallbackSessionInfo = buildUserSessionInsertRow({
       session_id: sessionId,
       user_id: userId,
       expires_at: expiresAt.toISOString(),
       created_at: now.toISOString(),
       last_activity: now.toISOString(),
-      is_active: true,
       ip_address: normalizeClientIpForInet(rawIp),
-      user_agent: request.headers.get('user-agent') || 'unknown'
-    }
+      user_agent: request.headers.get('user-agent') || 'unknown',
+    })
 
     const { error: insertError } = await createSupabaseServiceRoleClient()
       .from('user_sessions')
@@ -313,22 +316,18 @@ async function updateSessionActivity(sessionId: string): Promise<void> {
 }
 
 /**
- * Update session tokens
+ * Record that the session was refreshed. Access/refresh tokens are not stored on `user_sessions`
+ * (schema: session_id, user_id, ip_address, user_agent, timestamps, is_active only).
  */
-async function updateSessionTokens(
-  sessionId: string, 
-  accessToken: string, 
-  refreshToken: string
-): Promise<void> {
-  await createSupabaseServiceRoleClient()
+async function updateSessionTokens(sessionId: string): Promise<void> {
+  const { error } = await createSupabaseServiceRoleClient()
     .from('user_sessions')
-    .update({ 
-      last_activity: new Date().toISOString(),
-      access_token: accessToken,
-      refresh_token: refreshToken,
-      updated_at: new Date().toISOString()
-    })
+    .update({ last_activity: new Date().toISOString() })
     .eq('session_id', sessionId)
+
+  if (error) {
+    console.warn('[auth] user_sessions last_activity update after refresh failed:', error.message)
+  }
 }
 
 /**

--- a/lib/auth-utils.ts
+++ b/lib/auth-utils.ts
@@ -175,17 +175,12 @@ export async function refreshAccessToken(request: NextRequest): Promise<{ succes
     })
 
     if (error || !data.session) {
-      // Refresh failed; deactivate the session and clear cookies so we don't
-      // keep attempting upstream refreshes with a bad session.
+      // Refresh failed; deactivate the session so we don't keep attempting
+      // upstream refreshes with a bad session.
       try {
         await deactivateSession(sessionId)
       } catch (deactivateError) {
         console.error('Error deactivating session after refresh failure:', deactivateError)
-      }
-      try {
-        await clearAuthCookies()
-      } catch (cookieError) {
-        console.error('Error clearing auth cookies after refresh failure:', cookieError)
       }
       return { success: false }
     }
@@ -207,11 +202,6 @@ export async function refreshAccessToken(request: NextRequest): Promise<{ succes
         console.error('Error deactivating session after refresh exception:', deactivateError)
       }
     }
-    try {
-      await clearAuthCookies()
-    } catch (cookieError) {
-      console.error('Error clearing auth cookies after refresh exception:', cookieError)
-    }
     return { success: false }
   }
 }
@@ -230,12 +220,11 @@ export async function createUserSession(
   session: any,
   request: NextRequest
 ): Promise<string> {
-  // Import the enhanced session management. This implementation is responsible
-  // for creating the DB session row and returning a session ID, or throwing on
-  // failure.
-  const { createEnhancedSession } = await import('@/lib/session-management')
-
   try {
+    // Import the enhanced session management. This implementation is responsible
+    // for creating the DB session row and returning a session ID, or throwing on
+    // failure.
+    const { createEnhancedSession } = await import('@/lib/session-management')
     return await createEnhancedSession(userId, request)
   } catch (error) {
     console.error('Error creating enhanced session, falling back to basic session:', error)

--- a/lib/auth-utils.ts
+++ b/lib/auth-utils.ts
@@ -175,7 +175,18 @@ export async function refreshAccessToken(request: NextRequest): Promise<{ succes
     })
 
     if (error || !data.session) {
-      // Refresh failed; do not clear cookies so client can retry or user can re-auth
+      // Refresh failed; deactivate the session and clear cookies so we don't
+      // keep attempting upstream refreshes with a bad session.
+      try {
+        await deactivateSession(sessionId)
+      } catch (deactivateError) {
+        console.error('Error deactivating session after refresh failure:', deactivateError)
+      }
+      try {
+        await clearAuthCookies()
+      } catch (cookieError) {
+        console.error('Error clearing auth cookies after refresh failure:', cookieError)
+      }
       return { success: false }
     }
 
@@ -188,43 +199,81 @@ export async function refreshAccessToken(request: NextRequest): Promise<{ succes
     return { success: true, newToken: data.session.access_token }
   } catch (error) {
     console.error('Token refresh error:', error)
+    const sessionId = request.cookies.get(SESSION_ID_COOKIE_NAME)?.value
+    if (sessionId) {
+      try {
+        await deactivateSession(sessionId)
+      } catch (deactivateError) {
+        console.error('Error deactivating session after refresh exception:', deactivateError)
+      }
+    }
+    try {
+      await clearAuthCookies()
+    } catch (cookieError) {
+      console.error('Error clearing auth cookies after refresh exception:', cookieError)
+    }
     return { success: false }
   }
 }
 
 /**
  * Create a new session for a user (enhanced with security checks)
+ *
+ * This helper is the single entry point for creating `user_sessions` records.
+ * It will either delegate to the enhanced session management or fall back to a
+ * basic insert that mirrors the data written by the login route previously.
+ *
+ * On failure it throws so callers can decide how to fail the request.
  */
 export async function createUserSession(
-  userId: string, 
-  session: any, 
+  userId: string,
+  session: any,
   request: NextRequest
 ): Promise<string> {
-  // Import the enhanced session management
+  // Import the enhanced session management. This implementation is responsible
+  // for creating the DB session row and returning a session ID, or throwing on
+  // failure.
   const { createEnhancedSession } = await import('@/lib/session-management')
-  
+
   try {
     return await createEnhancedSession(userId, request)
   } catch (error) {
     console.error('Error creating enhanced session, falling back to basic session:', error)
-    
-    // Fallback to basic session creation
-    const sessionId = generateSessionId()
-    const expiresAt = new Date(Date.now() + SESSION_CONFIG.sessionIdExpiry * 1000)
 
-    const sessionInfo: Omit<SessionInfo, 'created_at'> = {
+    // Fallback to basic session creation that matches the historic login route
+    // behavior, including storing access/refresh tokens.
+    const sessionId = generateSessionId()
+    const now = new Date()
+    const expiresAt = session?.expires_at
+      ? new Date(session.expires_at * 1000)
+      : new Date(now.getTime() + SESSION_CONFIG.sessionIdExpiry * 1000)
+
+    const sessionInfo = {
       session_id: sessionId,
       user_id: userId,
-      last_activity: new Date().toISOString(),
-      ip_address: request.headers.get('x-forwarded-for') || request.headers.get('x-real-ip') || 'unknown',
-      user_agent: request.headers.get('user-agent') || 'unknown',
+      access_token: session?.access_token,
+      refresh_token: session?.refresh_token,
+      expires_at: expiresAt.toISOString(),
+      created_at: now.toISOString(),
+      updated_at: now.toISOString(),
+      last_activity: now.toISOString(),
       is_active: true,
-      expires_at: expiresAt.toISOString()
+      ip_address:
+        request.headers.get('x-forwarded-for') ||
+        request.headers.get('x-real-ip') ||
+        'unknown',
+      user_agent: request.headers.get('user-agent') || 'unknown',
+      device_info: {}
     }
 
-    await getSupabaseAdmin()
+    const { error: insertError } = await getSupabaseAdmin()
       .from('user_sessions')
       .insert(sessionInfo)
+
+    if (insertError) {
+      console.error('Failed to create basic session record:', insertError)
+      throw new Error(`Failed to create user session: ${insertError.message}`)
+    }
 
     return sessionId
   }

--- a/lib/auth-utils.ts
+++ b/lib/auth-utils.ts
@@ -15,6 +15,7 @@ import {
   PermissionAuditEntry
 } from '@/lib/auth-types'
 import { getCurrentUserDev } from '@/lib/auth-dev'
+import { normalizeClientIpForInet } from '@/lib/session-management'
 
 // Cookie names for authentication
 const AUTH_COOKIE_NAME = 'sb-auth-token'
@@ -100,14 +101,37 @@ export async function getCurrentUser(request: NextRequest): Promise<AuthUser | n
       .eq('session_id', sessionId)
       .eq('user_id', user.id)
       .eq('is_active', true)
-      .single()
+      .maybeSingle()
 
-    if (!sessionInfo) {
-      return null
+    let resolvedSession = sessionInfo
+
+    if (!resolvedSession) {
+      console.warn('[auth] Valid JWT but no user_sessions row; attempting repair', {
+        userId: user.id,
+        sessionId
+      })
+      try {
+        const { createEnhancedSession } = await import('@/lib/session-management')
+        await createEnhancedSession(user.id, request, sessionId)
+      } catch (repairError) {
+        console.error('[auth] Session repair failed:', repairError)
+        return null
+      }
+      const { data: repaired } = await getSupabaseAdmin()
+        .from('user_sessions')
+        .select('*')
+        .eq('session_id', sessionId)
+        .eq('user_id', user.id)
+        .eq('is_active', true)
+        .maybeSingle()
+      if (!repaired) {
+        return null
+      }
+      resolvedSession = repaired
     }
 
     // Check if session has expired
-    if (new Date(sessionInfo.expires_at) < new Date()) {
+    if (new Date(resolvedSession.expires_at) < new Date()) {
       await deactivateSession(sessionId)
       return null
     }
@@ -246,6 +270,12 @@ export async function createUserSession(
       ? new Date(session.expires_at * 1000)
       : new Date(now.getTime() + SESSION_CONFIG.sessionIdExpiry * 1000)
 
+    const rawIp =
+      request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+      request.headers.get('x-real-ip') ||
+      request.headers.get('cf-connecting-ip') ||
+      'unknown'
+
     const fallbackSessionInfo = {
       session_id: sessionId,
       user_id: userId,
@@ -253,10 +283,7 @@ export async function createUserSession(
       created_at: now.toISOString(),
       last_activity: now.toISOString(),
       is_active: true,
-      ip_address:
-        request.headers.get('x-forwarded-for') ||
-        request.headers.get('x-real-ip') ||
-        'unknown',
+      ip_address: normalizeClientIpForInet(rawIp),
       user_agent: request.headers.get('user-agent') || 'unknown'
     }
 

--- a/lib/auth-utils.ts
+++ b/lib/auth-utils.ts
@@ -94,18 +94,17 @@ export async function getCurrentUser(request: NextRequest): Promise<AuthUser | n
       return null
     }
 
-    // Check if session is still valid in our database
-    const { data: sessionInfo } = await createSupabaseServiceRoleClient()
+    // Check if session is still valid in our database (do not filter is_active on first read)
+    const { data: sessionRowAny } = await createSupabaseServiceRoleClient()
       .from('user_sessions')
       .select('*')
       .eq('session_id', sessionId)
       .eq('user_id', user.id)
-      .eq('is_active', true)
       .maybeSingle()
 
-    let resolvedSession = sessionInfo
+    let resolvedSession: typeof sessionRowAny = null
 
-    if (!resolvedSession) {
+    if (!sessionRowAny) {
       console.warn('[auth] Valid JWT but no user_sessions row; attempting repair', {
         userId: user.id,
         sessionId
@@ -128,6 +127,10 @@ export async function getCurrentUser(request: NextRequest): Promise<AuthUser | n
         return null
       }
       resolvedSession = repaired
+    } else if (sessionRowAny.is_active !== true) {
+      return null
+    } else {
+      resolvedSession = sessionRowAny
     }
 
     // Check if session has expired
@@ -334,21 +337,31 @@ async function updateSessionTokens(sessionId: string): Promise<void> {
  * Deactivate a session
  */
 async function deactivateSession(sessionId: string): Promise<void> {
-  await createSupabaseServiceRoleClient()
+  const { error } = await createSupabaseServiceRoleClient()
     .from('user_sessions')
     .update({ is_active: false })
     .eq('session_id', sessionId)
+
+  if (error) {
+    throw new Error(`deactivateSession failed for sessionId=${sessionId}: ${error.message}`)
+  }
 }
 
 /**
  * Deactivate all sessions for a user (except current one)
  */
 export async function deactivateOtherSessions(userId: string, currentSessionId: string): Promise<void> {
-  await createSupabaseServiceRoleClient()
+  const { error } = await createSupabaseServiceRoleClient()
     .from('user_sessions')
     .update({ is_active: false })
     .eq('user_id', userId)
     .neq('session_id', currentSessionId)
+
+  if (error) {
+    throw new Error(
+      `deactivateOtherSessions failed for userId=${userId} (excluding ${currentSessionId}): ${error.message}`
+    )
+  }
 }
 
 /**

--- a/lib/jwt-utils.ts
+++ b/lib/jwt-utils.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from 'next/server';
-import { getSupabaseAdmin } from '@/lib/supabase';
+import { createSupabaseServiceRoleClient, getSupabaseAdmin } from '@/lib/supabase';
 import { AuthErrorType } from '@/lib/auth-types';
 
 // JWT token validation and management utilities
@@ -180,7 +180,7 @@ export async function revokeAllUserTokens(userId: string): Promise<TokenRevocati
     }
 
     // Deactivate all sessions in database
-    await getSupabaseAdmin()
+    await createSupabaseServiceRoleClient()
       .from('user_sessions')
       .update({ is_active: false })
       .eq('user_id', userId);

--- a/lib/jwt-utils.ts
+++ b/lib/jwt-utils.ts
@@ -180,10 +180,17 @@ export async function revokeAllUserTokens(userId: string): Promise<TokenRevocati
     }
 
     // Deactivate all sessions in database
-    await createSupabaseServiceRoleClient()
+    const { error: deactivateError } = await createSupabaseServiceRoleClient()
       .from('user_sessions')
       .update({ is_active: false })
       .eq('user_id', userId);
+
+    if (deactivateError) {
+      return {
+        success: false,
+        error: deactivateError.message || 'Failed to deactivate user sessions'
+      };
+    }
 
     // Note: Supabase doesn't have a direct API to revoke all tokens for a user
     // The session deactivation above will prevent access via our session management

--- a/lib/session-management.ts
+++ b/lib/session-management.ts
@@ -194,7 +194,11 @@ export async function updateSessionActivity(
       session.ip_address != null
         ? normalizeClientIpForInet(String(session.ip_address))
         : null;
-    if (oldNorm !== newIPInet) {
+    if (
+      oldNorm != null &&
+      newIPInet != null &&
+      oldNorm !== newIPInet
+    ) {
       securityAlert = {
         event_type: 'unusual_location',
         session_id: sessionId,
@@ -224,14 +228,22 @@ export async function updateSessionActivity(
       };
     }
 
-    // Update session (INET column must receive null or a valid IP literal)
+    // Update session (omit ip_address when we could not normalize — preserves stored IP)
+    const updatePayload: {
+      last_activity: string
+      user_agent: string
+      ip_address?: string | null
+    } = {
+      last_activity: new Date().toISOString(),
+      user_agent: newUserAgent
+    }
+    if (newIPInet != null) {
+      updatePayload.ip_address = newIPInet
+    }
+
     const { error: updateError } = await createSupabaseServiceRoleClient()
       .from('user_sessions')
-      .update({
-        last_activity: new Date().toISOString(),
-        ip_address: newIPInet,
-        user_agent: newUserAgent
-      })
+      .update(updatePayload)
       .eq('session_id', sessionId);
 
     if (updateError) {
@@ -256,13 +268,21 @@ export async function updateSessionActivity(
  */
 export async function deactivateSession(sessionId: string, reason?: string): Promise<boolean> {
   try {
-    await createSupabaseServiceRoleClient()
+    const { error: updateError } = await createSupabaseServiceRoleClient()
       .from('user_sessions')
       .update({ 
         is_active: false,
         last_activity: new Date().toISOString()
       })
       .eq('session_id', sessionId);
+
+    if (updateError) {
+      console.error(
+        `session-management deactivateSession failed for sessionId=${sessionId}:`,
+        updateError.message
+      )
+      return false
+    }
 
     // Log session deactivation
     const session = await getSessionDetails(sessionId);

--- a/lib/session-management.ts
+++ b/lib/session-management.ts
@@ -1,6 +1,18 @@
+import { isIP } from 'net';
 import { NextRequest } from 'next/server';
 import { getSupabaseAdmin } from '@/lib/supabase';
 import { AuthErrorType } from '@/lib/auth-types';
+
+/**
+ * `user_sessions.ip_address` is PostgreSQL INET — only valid IP literals or null.
+ * Raw values like "unknown" or empty must not be inserted.
+ */
+export function normalizeClientIpForInet(raw: string): string | null {
+  if (!raw || raw === 'unknown') return null;
+  const trimmed = raw.trim();
+  if (isIP(trimmed) !== 0) return trimmed;
+  return null;
+}
 
 // Enhanced session management utilities
 export interface SessionDetails {
@@ -102,9 +114,9 @@ export async function createEnhancedSession(
   try {
     const id = sessionId || generateSecureSessionId();
     const userAgent = request.headers.get('user-agent') || 'unknown';
-    const ipAddress = getClientIP(request);
-    const location = await getLocationFromIP(ipAddress);
-    
+    const ipRaw = getClientIP(request);
+    const ipAddress = normalizeClientIpForInet(ipRaw);
+
     const sessionData = {
       session_id: id,
       user_id: userId,
@@ -116,9 +128,13 @@ export async function createEnhancedSession(
       expires_at: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString() // 30 days
     };
 
-    await getSupabaseAdmin()
+    const { error: insertError } = await getSupabaseAdmin()
       .from('user_sessions')
       .insert(sessionData);
+
+    if (insertError) {
+      throw new Error(`user_sessions insert failed: ${insertError.message}`);
+    }
 
     // Check for security events
     await checkSessionSecurity(userId, sessionData, request);
@@ -143,22 +159,27 @@ export async function updateSessionActivity(
       return { success: false };
     }
 
-    const newIP = getClientIP(request);
+    const newIPRaw = getClientIP(request);
+    const newIPInet = normalizeClientIpForInet(newIPRaw);
     const newUserAgent = request.headers.get('user-agent') || 'unknown';
 
     // Check for suspicious activity
     let securityAlert: SessionSecurityEvent | undefined;
 
-    if (session.ip_address !== newIP) {
+    const oldNorm =
+      session.ip_address != null
+        ? normalizeClientIpForInet(String(session.ip_address))
+        : null;
+    if (oldNorm !== newIPInet) {
       securityAlert = {
         event_type: 'unusual_location',
         session_id: sessionId,
         user_id: session.user_id,
         details: {
           old_ip: session.ip_address,
-          new_ip: newIP,
+          new_ip: newIPRaw,
           old_location: session.location,
-          new_location: await getLocationFromIP(newIP)
+          new_location: await getLocationFromIP(newIPRaw)
         },
         severity: 'medium',
         created_at: new Date().toISOString()
@@ -179,15 +200,20 @@ export async function updateSessionActivity(
       };
     }
 
-    // Update session
-    await getSupabaseAdmin()
+    // Update session (INET column must receive null or a valid IP literal)
+    const { error: updateError } = await getSupabaseAdmin()
       .from('user_sessions')
       .update({
         last_activity: new Date().toISOString(),
-        ip_address: newIP,
+        ip_address: newIPInet,
         user_agent: newUserAgent
       })
       .eq('session_id', sessionId);
+
+    if (updateError) {
+      console.error('user_sessions update failed:', updateError);
+      return { success: false };
+    }
 
     // Log security event if detected
     if (securityAlert) {

--- a/lib/session-management.ts
+++ b/lib/session-management.ts
@@ -14,6 +14,33 @@ export function normalizeClientIpForInet(raw: string): string | null {
   return null;
 }
 
+/**
+ * Insert row for public.user_sessions — must match migrations (no token columns).
+ * Always use this for inserts so PostgREST never receives stray keys (e.g. access_token).
+ */
+export function buildUserSessionInsertRow(params: {
+  session_id: string;
+  user_id: string;
+  ip_address: string | null;
+  user_agent: string;
+  expires_at: string;
+  created_at?: string;
+  last_activity?: string;
+  is_active?: boolean;
+}) {
+  const now = new Date().toISOString();
+  return {
+    session_id: params.session_id,
+    user_id: params.user_id,
+    ip_address: params.ip_address,
+    user_agent: params.user_agent,
+    is_active: params.is_active ?? true,
+    created_at: params.created_at ?? now,
+    last_activity: params.last_activity ?? now,
+    expires_at: params.expires_at,
+  };
+}
+
 // Enhanced session management utilities
 export interface SessionDetails {
   session_id: string;
@@ -117,16 +144,13 @@ export async function createEnhancedSession(
     const ipRaw = getClientIP(request);
     const ipAddress = normalizeClientIpForInet(ipRaw);
 
-    const sessionData = {
+    const sessionData = buildUserSessionInsertRow({
       session_id: id,
       user_id: userId,
       ip_address: ipAddress,
       user_agent: userAgent,
-      is_active: true,
-      created_at: new Date().toISOString(),
-      last_activity: new Date().toISOString(),
-      expires_at: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString() // 30 days
-    };
+      expires_at: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(), // 30 days
+    });
 
     const { error: insertError } = await createSupabaseServiceRoleClient()
       .from('user_sessions')

--- a/lib/session-management.ts
+++ b/lib/session-management.ts
@@ -1,6 +1,6 @@
 import { isIP } from 'net';
 import { NextRequest } from 'next/server';
-import { getSupabaseAdmin } from '@/lib/supabase';
+import { createSupabaseServiceRoleClient } from '@/lib/supabase';
 import { AuthErrorType } from '@/lib/auth-types';
 
 /**
@@ -54,7 +54,7 @@ export interface SessionSecurityEvent {
  */
 export async function getSessionDetails(sessionId: string): Promise<SessionDetails | null> {
   try {
-    const { data, error } = await getSupabaseAdmin()
+    const { data, error } = await createSupabaseServiceRoleClient()
       .from('user_sessions')
       .select('*')
       .eq('session_id', sessionId)
@@ -81,7 +81,7 @@ export async function getSessionDetails(sessionId: string): Promise<SessionDetai
  */
 export async function getUserSessionsDetailed(userId: string): Promise<SessionDetails[]> {
   try {
-    const { data, error } = await getSupabaseAdmin()
+    const { data, error } = await createSupabaseServiceRoleClient()
       .from('user_sessions')
       .select('*')
       .eq('user_id', userId)
@@ -128,7 +128,7 @@ export async function createEnhancedSession(
       expires_at: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString() // 30 days
     };
 
-    const { error: insertError } = await getSupabaseAdmin()
+    const { error: insertError } = await createSupabaseServiceRoleClient()
       .from('user_sessions')
       .insert(sessionData);
 
@@ -201,7 +201,7 @@ export async function updateSessionActivity(
     }
 
     // Update session (INET column must receive null or a valid IP literal)
-    const { error: updateError } = await getSupabaseAdmin()
+    const { error: updateError } = await createSupabaseServiceRoleClient()
       .from('user_sessions')
       .update({
         last_activity: new Date().toISOString(),
@@ -232,7 +232,7 @@ export async function updateSessionActivity(
  */
 export async function deactivateSession(sessionId: string, reason?: string): Promise<boolean> {
   try {
-    await getSupabaseAdmin()
+    await createSupabaseServiceRoleClient()
       .from('user_sessions')
       .update({ 
         is_active: false,
@@ -269,7 +269,7 @@ export async function deactivateOtherSessions(
   reason?: string
 ): Promise<number> {
   try {
-    const { data, error } = await getSupabaseAdmin()
+    const { data, error } = await createSupabaseServiceRoleClient()
       .from('user_sessions')
       .update({ 
         is_active: false,
@@ -309,7 +309,7 @@ export async function deactivateOtherSessions(
  */
 export async function getSessionAnalytics(userId: string): Promise<SessionAnalytics> {
   try {
-    const { data: sessions } = await getSupabaseAdmin()
+    const { data: sessions } = await createSupabaseServiceRoleClient()
       .from('user_sessions')
       .select('*')
       .eq('user_id', userId);
@@ -374,7 +374,7 @@ export async function getSessionAnalytics(userId: string): Promise<SessionAnalyt
  */
 export async function cleanupExpiredSessions(): Promise<number> {
   try {
-    const { data, error } = await getSupabaseAdmin()
+    const { data, error } = await createSupabaseServiceRoleClient()
       .from('user_sessions')
       .update({ is_active: false })
       .lt('expires_at', new Date().toISOString())
@@ -448,7 +448,7 @@ async function checkSessionSecurity(
 ): Promise<void> {
   try {
     // Check for concurrent session limits
-    const { data: activeSessions } = await getSupabaseAdmin()
+    const { data: activeSessions } = await createSupabaseServiceRoleClient()
       .from('user_sessions')
       .select('session_id')
       .eq('user_id', userId)

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -5,6 +5,62 @@ const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder
 const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || 'placeholder-service-key'
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'placeholder-anon-key'
 
+/** Decode `role` claim from a Supabase API JWT (anon / authenticated / service_role). */
+function decodeSupabaseJwtRole(jwt: string): string | undefined {
+  try {
+    const parts = jwt.split('.')
+    if (parts.length !== 3) return undefined
+    const payload = JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8')) as {
+      role?: string
+    }
+    return payload.role
+  } catch {
+    return undefined
+  }
+}
+
+let loggedServiceKeyWarning = false
+
+/**
+ * Returns a user-facing message if the server key will cause RLS failures on admin writes
+ * (e.g. anon key pasted into SUPABASE_SERVICE_ROLE_KEY). Otherwise null.
+ */
+export function getSupabaseServiceKeyMisconfigurationMessage(): string | null {
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!key || key === 'placeholder-service-key') {
+    return (
+      'SUPABASE_SERVICE_ROLE_KEY is not set. Add the service_role secret from Supabase ' +
+      '(Project Settings → API) to your server environment (e.g. Vercel). Do not use the anon key.'
+    )
+  }
+  const role = decodeSupabaseJwtRole(key)
+  if (role === 'anon' || role === 'authenticated') {
+    return (
+      `SUPABASE_SERVICE_ROLE_KEY is the "${role}" key. Use the service_role secret from Supabase ` +
+      '(Project Settings → API). The anon/authenticated keys cannot insert into user_sessions and trigger row-level security errors.'
+    )
+  }
+  if (role && role !== 'service_role') {
+    return (
+      `SUPABASE_SERVICE_ROLE_KEY must be the service_role JWT (role claim: service_role). ` +
+      `This key decodes as role "${role}".`
+    )
+  }
+  return null
+}
+
+function warnIfServiceRoleKeyWrongForServer(): void {
+  if (loggedServiceKeyWarning || supabaseServiceKey === 'placeholder-service-key') return
+  const role = decodeSupabaseJwtRole(supabaseServiceKey)
+  if (role === 'anon' || role === 'authenticated' || (role && role !== 'service_role')) {
+    loggedServiceKeyWarning = true
+    console.error(
+      '[supabase] SUPABASE_SERVICE_ROLE_KEY is not the service_role secret. Server writes hit RLS. ' +
+        `Decoded JWT role: ${role ?? 'unknown'}. Fix in Vercel / .env (Project Settings → API in Supabase).`
+    )
+  }
+}
+
 // Check if we're using placeholder values
 const isUsingPlaceholders = supabaseUrl === 'https://placeholder.supabase.co' || 
                            supabaseServiceKey === 'placeholder-service-key' || 
@@ -17,6 +73,7 @@ let supabaseClientInstance: any = null;
 // Function to get Supabase admin client (for server-side operations)
 export function getSupabaseAdmin() {
   if (!supabaseAdminInstance) {
+    warnIfServiceRoleKeyWrongForServer()
     supabaseAdminInstance = createClient(supabaseUrl, supabaseServiceKey, {
       auth: {
         autoRefreshToken: false,
@@ -25,6 +82,22 @@ export function getSupabaseAdmin() {
     });
   }
   return supabaseAdminInstance;
+}
+
+/**
+ * Fresh service-role client with no user session. Use for `user_sessions` (and similar) right
+ * after `auth.signInWithPassword` / `refreshSession` on `getSupabaseAdmin()`: those calls set
+ * the user JWT as the PostgREST Authorization header, so RLS runs as the user and inserts fail.
+ * @see https://supabase.com/docs/guides/troubleshooting/why-is-my-service-role-key-client-getting-rls-errors-or-not-returning-data-7_1K9z
+ */
+export function createSupabaseServiceRoleClient() {
+  warnIfServiceRoleKeyWrongForServer()
+  return createClient(supabaseUrl, supabaseServiceKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false
+    }
+  })
 }
 
 // Server-side client with service role key for admin operations

--- a/setup-auth-tables.sql
+++ b/setup-auth-tables.sql
@@ -118,7 +118,7 @@ DROP POLICY IF EXISTS "Admins can view all roles" ON user_roles;
 CREATE POLICY "Users can view their own role" ON user_roles
     FOR SELECT USING (auth.uid()::text = user_id);
 CREATE POLICY "Admins can view all roles" ON user_roles
-    FOR SELECT USING (public.is_current_user_admin());
+    FOR SELECT TO authenticated USING (public.is_current_user_admin());
 
 -- Grant permissions
 GRANT ALL ON user_roles TO authenticated;
@@ -163,7 +163,7 @@ DROP POLICY IF EXISTS "Admins can view all permissions" ON user_permissions;
 CREATE POLICY "Users can view their own permissions" ON user_permissions
     FOR SELECT USING (auth.uid()::text = user_id);
 CREATE POLICY "Admins can view all permissions" ON user_permissions
-    FOR SELECT USING (public.is_current_user_admin());
+    FOR SELECT TO authenticated USING (public.is_current_user_admin());
 
 -- Grant permissions
 GRANT ALL ON user_permissions TO authenticated;

--- a/setup-auth-tables.sql
+++ b/setup-auth-tables.sql
@@ -87,6 +87,26 @@ CREATE TRIGGER update_user_roles_updated_at
     FOR EACH ROW 
     EXECUTE FUNCTION update_updated_at_column();
 
+-- Admin check for RLS (SECURITY DEFINER avoids infinite recursion when used from user_roles policies)
+CREATE OR REPLACE FUNCTION public.is_current_user_admin()
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.user_roles
+    WHERE user_id = (SELECT auth.uid()::text)
+      AND role = 'ADMIN'
+  );
+$$;
+
+REVOKE ALL ON FUNCTION public.is_current_user_admin() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.is_current_user_admin() TO authenticated;
+GRANT EXECUTE ON FUNCTION public.is_current_user_admin() TO service_role;
+
 -- Enable RLS
 ALTER TABLE user_roles ENABLE ROW LEVEL SECURITY;
 
@@ -98,12 +118,7 @@ DROP POLICY IF EXISTS "Admins can view all roles" ON user_roles;
 CREATE POLICY "Users can view their own role" ON user_roles
     FOR SELECT USING (auth.uid()::text = user_id);
 CREATE POLICY "Admins can view all roles" ON user_roles
-    FOR SELECT USING (
-        EXISTS (
-            SELECT 1 FROM user_roles 
-            WHERE user_id = auth.uid()::text AND role = 'ADMIN'
-        )
-    );
+    FOR SELECT USING (public.is_current_user_admin());
 
 -- Grant permissions
 GRANT ALL ON user_roles TO authenticated;
@@ -148,12 +163,7 @@ DROP POLICY IF EXISTS "Admins can view all permissions" ON user_permissions;
 CREATE POLICY "Users can view their own permissions" ON user_permissions
     FOR SELECT USING (auth.uid()::text = user_id);
 CREATE POLICY "Admins can view all permissions" ON user_permissions
-    FOR SELECT USING (
-        EXISTS (
-            SELECT 1 FROM user_roles 
-            WHERE user_id = auth.uid()::text AND role = 'ADMIN'
-        )
-    );
+    FOR SELECT USING (public.is_current_user_admin());
 
 -- Grant permissions
 GRANT ALL ON user_permissions TO authenticated;

--- a/supabase/migrations/20260329000000_fix_user_roles_rls_recursion.sql
+++ b/supabase/migrations/20260329000000_fix_user_roles_rls_recursion.sql
@@ -1,0 +1,98 @@
+-- Fix PostgreSQL 42P17: infinite recursion in RLS on user_roles when the
+-- "Admins can view all roles" policy subqueries user_roles under the same RLS.
+-- Also centralize admin checks so other policies do not depend on fragile subqueries.
+
+CREATE OR REPLACE FUNCTION public.is_current_user_admin()
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.user_roles
+    WHERE user_id = (SELECT auth.uid()::text)
+      AND role = 'ADMIN'
+  );
+$$;
+
+REVOKE ALL ON FUNCTION public.is_current_user_admin() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.is_current_user_admin() TO authenticated;
+GRANT EXECUTE ON FUNCTION public.is_current_user_admin() TO service_role;
+
+-- user_roles
+DROP POLICY IF EXISTS "Admins can view all roles" ON public.user_roles;
+CREATE POLICY "Admins can view all roles" ON public.user_roles
+  FOR SELECT USING (public.is_current_user_admin());
+
+-- user_permissions (from consolidated schema)
+DROP POLICY IF EXISTS "Admins can view all permissions" ON public.user_permissions;
+CREATE POLICY "Admins can view all permissions" ON public.user_permissions
+  FOR SELECT USING (public.is_current_user_admin());
+
+-- granular permissions tables
+DROP POLICY IF EXISTS "Admins can view all custom permissions" ON public.custom_permissions;
+CREATE POLICY "Admins can view all custom permissions" ON public.custom_permissions
+  FOR SELECT USING (public.is_current_user_admin());
+
+DROP POLICY IF EXISTS "Admins can create custom permissions" ON public.custom_permissions;
+CREATE POLICY "Admins can create custom permissions" ON public.custom_permissions
+  FOR INSERT WITH CHECK (public.is_current_user_admin());
+
+DROP POLICY IF EXISTS "Admins can update all custom permissions" ON public.custom_permissions;
+CREATE POLICY "Admins can update all custom permissions" ON public.custom_permissions
+  FOR UPDATE USING (public.is_current_user_admin());
+
+DROP POLICY IF EXISTS "Admins can view all user custom permissions" ON public.user_custom_permissions;
+CREATE POLICY "Admins can view all user custom permissions" ON public.user_custom_permissions
+  FOR SELECT USING (public.is_current_user_admin());
+
+DROP POLICY IF EXISTS "Admins can manage user custom permissions" ON public.user_custom_permissions;
+CREATE POLICY "Admins can manage user custom permissions" ON public.user_custom_permissions
+  FOR ALL USING (public.is_current_user_admin());
+
+DROP POLICY IF EXISTS "Admins can view all resource permissions" ON public.resource_permissions;
+CREATE POLICY "Admins can view all resource permissions" ON public.resource_permissions
+  FOR SELECT USING (public.is_current_user_admin());
+
+DROP POLICY IF EXISTS "Admins can manage resource permissions" ON public.resource_permissions;
+CREATE POLICY "Admins can manage resource permissions" ON public.resource_permissions
+  FOR ALL USING (public.is_current_user_admin());
+
+DROP POLICY IF EXISTS "Admins can view all permission overrides" ON public.permission_overrides;
+CREATE POLICY "Admins can view all permission overrides" ON public.permission_overrides
+  FOR SELECT USING (public.is_current_user_admin());
+
+DROP POLICY IF EXISTS "Admins can manage permission overrides" ON public.permission_overrides;
+CREATE POLICY "Admins can manage permission overrides" ON public.permission_overrides
+  FOR ALL USING (public.is_current_user_admin());
+
+DROP POLICY IF EXISTS "Admins can view all permission audit logs" ON public.permission_audit_log;
+CREATE POLICY "Admins can view all permission audit logs" ON public.permission_audit_log
+  FOR SELECT USING (public.is_current_user_admin());
+
+-- activity logging tables
+DROP POLICY IF EXISTS "Admins can view all activity logs" ON public.activity_logs;
+CREATE POLICY "Admins can view all activity logs" ON public.activity_logs
+  FOR SELECT USING (public.is_current_user_admin());
+
+DROP POLICY IF EXISTS "Admins can manage activity logs" ON public.activity_logs;
+CREATE POLICY "Admins can manage activity logs" ON public.activity_logs
+  FOR ALL USING (public.is_current_user_admin());
+
+DROP POLICY IF EXISTS "Admins can view activity log stats" ON public.activity_log_stats;
+CREATE POLICY "Admins can view activity log stats" ON public.activity_log_stats
+  FOR SELECT USING (public.is_current_user_admin());
+
+DROP POLICY IF EXISTS "Admins can view retention policies" ON public.activity_log_retention_policies;
+CREATE POLICY "Admins can view retention policies" ON public.activity_log_retention_policies
+  FOR SELECT USING (public.is_current_user_admin());
+
+DROP POLICY IF EXISTS "Admins can manage retention policies" ON public.activity_log_retention_policies;
+CREATE POLICY "Admins can manage retention policies" ON public.activity_log_retention_policies
+  FOR ALL USING (public.is_current_user_admin());
+
+DROP POLICY IF EXISTS "Admins can view all exports" ON public.activity_log_exports;
+CREATE POLICY "Admins can view all exports" ON public.activity_log_exports
+  FOR SELECT USING (public.is_current_user_admin());

--- a/supabase/migrations/20260329000000_fix_user_roles_rls_recursion.sql
+++ b/supabase/migrations/20260329000000_fix_user_roles_rls_recursion.sql
@@ -24,75 +24,75 @@ GRANT EXECUTE ON FUNCTION public.is_current_user_admin() TO service_role;
 -- user_roles
 DROP POLICY IF EXISTS "Admins can view all roles" ON public.user_roles;
 CREATE POLICY "Admins can view all roles" ON public.user_roles
-  FOR SELECT USING (public.is_current_user_admin());
+  FOR SELECT TO authenticated USING (public.is_current_user_admin());
 
 -- user_permissions (from consolidated schema)
 DROP POLICY IF EXISTS "Admins can view all permissions" ON public.user_permissions;
 CREATE POLICY "Admins can view all permissions" ON public.user_permissions
-  FOR SELECT USING (public.is_current_user_admin());
+  FOR SELECT TO authenticated USING (public.is_current_user_admin());
 
 -- granular permissions tables
 DROP POLICY IF EXISTS "Admins can view all custom permissions" ON public.custom_permissions;
 CREATE POLICY "Admins can view all custom permissions" ON public.custom_permissions
-  FOR SELECT USING (public.is_current_user_admin());
+  FOR SELECT TO authenticated USING (public.is_current_user_admin());
 
 DROP POLICY IF EXISTS "Admins can create custom permissions" ON public.custom_permissions;
 CREATE POLICY "Admins can create custom permissions" ON public.custom_permissions
-  FOR INSERT WITH CHECK (public.is_current_user_admin());
+  FOR INSERT TO authenticated WITH CHECK (public.is_current_user_admin());
 
 DROP POLICY IF EXISTS "Admins can update all custom permissions" ON public.custom_permissions;
 CREATE POLICY "Admins can update all custom permissions" ON public.custom_permissions
-  FOR UPDATE USING (public.is_current_user_admin());
+  FOR UPDATE TO authenticated USING (public.is_current_user_admin());
 
 DROP POLICY IF EXISTS "Admins can view all user custom permissions" ON public.user_custom_permissions;
 CREATE POLICY "Admins can view all user custom permissions" ON public.user_custom_permissions
-  FOR SELECT USING (public.is_current_user_admin());
+  FOR SELECT TO authenticated USING (public.is_current_user_admin());
 
 DROP POLICY IF EXISTS "Admins can manage user custom permissions" ON public.user_custom_permissions;
 CREATE POLICY "Admins can manage user custom permissions" ON public.user_custom_permissions
-  FOR ALL USING (public.is_current_user_admin());
+  FOR ALL TO authenticated USING (public.is_current_user_admin());
 
 DROP POLICY IF EXISTS "Admins can view all resource permissions" ON public.resource_permissions;
 CREATE POLICY "Admins can view all resource permissions" ON public.resource_permissions
-  FOR SELECT USING (public.is_current_user_admin());
+  FOR SELECT TO authenticated USING (public.is_current_user_admin());
 
 DROP POLICY IF EXISTS "Admins can manage resource permissions" ON public.resource_permissions;
 CREATE POLICY "Admins can manage resource permissions" ON public.resource_permissions
-  FOR ALL USING (public.is_current_user_admin());
+  FOR ALL TO authenticated USING (public.is_current_user_admin());
 
 DROP POLICY IF EXISTS "Admins can view all permission overrides" ON public.permission_overrides;
 CREATE POLICY "Admins can view all permission overrides" ON public.permission_overrides
-  FOR SELECT USING (public.is_current_user_admin());
+  FOR SELECT TO authenticated USING (public.is_current_user_admin());
 
 DROP POLICY IF EXISTS "Admins can manage permission overrides" ON public.permission_overrides;
 CREATE POLICY "Admins can manage permission overrides" ON public.permission_overrides
-  FOR ALL USING (public.is_current_user_admin());
+  FOR ALL TO authenticated USING (public.is_current_user_admin());
 
 DROP POLICY IF EXISTS "Admins can view all permission audit logs" ON public.permission_audit_log;
 CREATE POLICY "Admins can view all permission audit logs" ON public.permission_audit_log
-  FOR SELECT USING (public.is_current_user_admin());
+  FOR SELECT TO authenticated USING (public.is_current_user_admin());
 
 -- activity logging tables
 DROP POLICY IF EXISTS "Admins can view all activity logs" ON public.activity_logs;
 CREATE POLICY "Admins can view all activity logs" ON public.activity_logs
-  FOR SELECT USING (public.is_current_user_admin());
+  FOR SELECT TO authenticated USING (public.is_current_user_admin());
 
 DROP POLICY IF EXISTS "Admins can manage activity logs" ON public.activity_logs;
 CREATE POLICY "Admins can manage activity logs" ON public.activity_logs
-  FOR ALL USING (public.is_current_user_admin());
+  FOR ALL TO authenticated USING (public.is_current_user_admin());
 
 DROP POLICY IF EXISTS "Admins can view activity log stats" ON public.activity_log_stats;
 CREATE POLICY "Admins can view activity log stats" ON public.activity_log_stats
-  FOR SELECT USING (public.is_current_user_admin());
+  FOR SELECT TO authenticated USING (public.is_current_user_admin());
 
 DROP POLICY IF EXISTS "Admins can view retention policies" ON public.activity_log_retention_policies;
 CREATE POLICY "Admins can view retention policies" ON public.activity_log_retention_policies
-  FOR SELECT USING (public.is_current_user_admin());
+  FOR SELECT TO authenticated USING (public.is_current_user_admin());
 
 DROP POLICY IF EXISTS "Admins can manage retention policies" ON public.activity_log_retention_policies;
 CREATE POLICY "Admins can manage retention policies" ON public.activity_log_retention_policies
-  FOR ALL USING (public.is_current_user_admin());
+  FOR ALL TO authenticated USING (public.is_current_user_admin());
 
 DROP POLICY IF EXISTS "Admins can view all exports" ON public.activity_log_exports;
 CREATE POLICY "Admins can view all exports" ON public.activity_log_exports
-  FOR SELECT USING (public.is_current_user_admin());
+  FOR SELECT TO authenticated USING (public.is_current_user_admin());


### PR DESCRIPTION
…, fail login if session insert fails

- auth-utils: remove clearAuthCookies() from refreshAccessToken(request) on failure so requireAuth 401 responses do not wipe cookies
- login: return 500 when user_sessions insert fails instead of succeeding with cookies but no DB session (getCurrentUser would then return null)

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Registration can now return a "requires manual login" outcome that shows an informational message and directs users to the login page.

* **Bug Fixes**
  * Auth errors now surface when session persistence or service-key misconfiguration prevents login/registration; failed refreshes deactivate stale sessions and login/session creation failures return 5xx.
  * Admin/session RLS recursion issues fixed for reliable admin views.

* **Refactor**
  * Session lifecycle and client-IP handling consolidated for more consistent session management.

* **Tests**
  * Expanded auth and session test coverage.

* **Chores**
  * .env example documents required service-role key.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->